### PR TITLE
feat: add tenant-aware telemetry with automatic claim attribution

### DIFF
--- a/telemetry/attributes.go
+++ b/telemetry/attributes.go
@@ -1,0 +1,63 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/pitabwire/frame/security"
+)
+
+// Attribute keys for multi-tenant context.
+//
+//nolint:gochecknoglobals // OpenTelemetry attribute keys must be global for reuse
+var (
+	AttrTenantKey    = attribute.Key("tenant_id")
+	AttrPartitionKey = attribute.Key("partition_id")
+)
+
+// TenantAttributes extracts tenant_id and partition_id from the context's
+// security claims and returns them as OpenTelemetry attributes.
+// When claims are absent or fields are empty, those attributes are omitted
+// rather than recorded as blank strings. This makes the function safe to call
+// unconditionally — unauthenticated or pre-auth code paths simply get an
+// empty slice.
+func TenantAttributes(ctx context.Context) []attribute.KeyValue {
+	claims := security.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil
+	}
+
+	var attrs []attribute.KeyValue
+
+	if tid := claims.GetTenantID(); tid != "" {
+		attrs = append(attrs, AttrTenantKey.String(tid))
+	}
+
+	if pid := claims.GetPartitionID(); pid != "" {
+		attrs = append(attrs, AttrPartitionKey.String(pid))
+	}
+
+	return attrs
+}
+
+// WithTenantAttributes returns a metric.MeasurementOption that attaches
+// tenant_id and partition_id from the context. Services use this when
+// recording custom product metrics so every data point is automatically
+// attributed to the correct tenant and partition.
+//
+// Usage:
+//
+//	counter.Add(ctx, 1,
+//	    telemetry.WithTenantAttributes(ctx),
+//	    metric.WithAttributes(attribute.String("login_method", "email")),
+//	)
+func WithTenantAttributes(ctx context.Context) metric.MeasurementOption {
+	attrs := TenantAttributes(ctx)
+	if len(attrs) == 0 {
+		return metric.WithAttributes()
+	}
+
+	return metric.WithAttributes(attrs...)
+}

--- a/telemetry/attributes_test.go
+++ b/telemetry/attributes_test.go
@@ -1,0 +1,107 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/pitabwire/frame/security"
+	"github.com/pitabwire/frame/telemetry"
+)
+
+func TestTenantAttributes_NoClaims(t *testing.T) {
+	ctx := context.Background()
+	attrs := telemetry.TenantAttributes(ctx)
+	require.Nil(t, attrs)
+}
+
+func TestTenantAttributes_EmptyClaims(t *testing.T) {
+	claims := &security.AuthenticationClaims{}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	attrs := telemetry.TenantAttributes(ctx)
+	require.Empty(t, attrs)
+}
+
+func TestTenantAttributes_TenantOnly(t *testing.T) {
+	claims := &security.AuthenticationClaims{
+		TenantID: "tenant-123",
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	attrs := telemetry.TenantAttributes(ctx)
+	require.Len(t, attrs, 1)
+	require.Equal(t, attribute.Key("tenant_id"), attrs[0].Key)
+	require.Equal(t, "tenant-123", attrs[0].Value.AsString())
+}
+
+func TestTenantAttributes_PartitionOnly(t *testing.T) {
+	claims := &security.AuthenticationClaims{
+		PartitionID: "partition-456",
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	attrs := telemetry.TenantAttributes(ctx)
+	require.Len(t, attrs, 1)
+	require.Equal(t, attribute.Key("partition_id"), attrs[0].Key)
+	require.Equal(t, "partition-456", attrs[0].Value.AsString())
+}
+
+func TestTenantAttributes_BothPresent(t *testing.T) {
+	claims := &security.AuthenticationClaims{
+		TenantID:    "tenant-123",
+		PartitionID: "partition-456",
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	attrs := telemetry.TenantAttributes(ctx)
+	require.Len(t, attrs, 2)
+
+	attrMap := make(map[attribute.Key]string)
+	for _, a := range attrs {
+		attrMap[a.Key] = a.Value.AsString()
+	}
+
+	require.Equal(t, "tenant-123", attrMap[telemetry.AttrTenantKey])
+	require.Equal(t, "partition-456", attrMap[telemetry.AttrPartitionKey])
+}
+
+func TestTenantAttributes_FromExtMap(t *testing.T) {
+	claims := &security.AuthenticationClaims{
+		Ext: map[string]any{
+			"tenant_id":    "ext-tenant",
+			"partition_id": "ext-partition",
+		},
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	attrs := telemetry.TenantAttributes(ctx)
+	require.Len(t, attrs, 2)
+
+	attrMap := make(map[attribute.Key]string)
+	for _, a := range attrs {
+		attrMap[a.Key] = a.Value.AsString()
+	}
+
+	require.Equal(t, "ext-tenant", attrMap[telemetry.AttrTenantKey])
+	require.Equal(t, "ext-partition", attrMap[telemetry.AttrPartitionKey])
+}
+
+func TestWithTenantAttributes_NoClaims(t *testing.T) {
+	ctx := context.Background()
+	opt := telemetry.WithTenantAttributes(ctx)
+	require.NotNil(t, opt)
+}
+
+func TestWithTenantAttributes_WithClaims(t *testing.T) {
+	claims := &security.AuthenticationClaims{
+		TenantID:    "tenant-789",
+		PartitionID: "partition-012",
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	opt := telemetry.WithTenantAttributes(ctx)
+	require.NotNil(t, opt)
+}

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -74,7 +74,8 @@ func Views(pkg string) []sdkmetric.View {
 							Boundaries: defaultMillisecondsBoundaries,
 						},
 						AttributeFilter: func(kv attribute.KeyValue) bool {
-							return kv.Key == AttrPackageKey || kv.Key == AttrMethodKey
+							return kv.Key == AttrPackageKey || kv.Key == AttrMethodKey ||
+								kv.Key == AttrTenantKey || kv.Key == AttrPartitionKey
 						},
 					}, true
 				}
@@ -92,7 +93,8 @@ func Views(pkg string) []sdkmetric.View {
 						Description: "Count of method calls by provider, method and status.",
 						Aggregation: sdkmetric.DefaultAggregationSelector(sdkmetric.InstrumentKindCounter),
 						AttributeFilter: func(kv attribute.KeyValue) bool {
-							return kv.Key == AttrMethodKey || kv.Key == AttrStatusKey
+							return kv.Key == AttrMethodKey || kv.Key == AttrStatusKey ||
+								kv.Key == AttrTenantKey || kv.Key == AttrPartitionKey
 						},
 					}, true
 				}

--- a/telemetry/trace.go
+++ b/telemetry/trace.go
@@ -68,6 +68,8 @@ func (t *tracer) Start(
 }
 
 // End completes a span with error information if applicable.
+// When security claims are present in the context, tenant_id and partition_id
+// are automatically added to both the span attributes and the latency metric.
 func (t *tracer) End(ctx context.Context, span trace.Span, err error, options ...trace.SpanEndOption) {
 	startTimeValue := ctx.Value(startTimeContextKey)
 	startTime, ok := startTimeValue.(time.Time)
@@ -79,6 +81,9 @@ func (t *tracer) End(ctx context.Context, span trace.Span, err error, options ..
 		return
 	}
 	elapsed := time.Since(startTime)
+
+	// Extract tenant attributes from context claims (nil-safe).
+	tenantAttrs := TenantAttributes(ctx)
 
 	if err != nil {
 		options = append(options, trace.WithStackTrace(true))
@@ -93,6 +98,10 @@ func (t *tracer) End(ctx context.Context, span trace.Span, err error, options ..
 		span.SetStatus(codes.Ok, "")
 	}
 
+	if len(tenantAttrs) > 0 {
+		span.SetAttributes(tenantAttrs...)
+	}
+
 	span.End(options...)
 
 	methodNameValue := ctx.Value(methodNameContextKey)
@@ -105,12 +114,15 @@ func (t *tracer) End(ctx context.Context, span trace.Span, err error, options ..
 		return
 	}
 
+	metricAttrs := []attribute.KeyValue{
+		AttrStatusKey.String(ErrorCode(err)),
+		AttrMethodKey.String(methodName),
+	}
+	metricAttrs = append(metricAttrs, tenantAttrs...)
+
 	t.latencyMeasure.Record(ctx,
 		float64(elapsed.Milliseconds()),
-
-		metric.WithAttributes(
-			AttrStatusKey.String(ErrorCode(err)),
-			AttrMethodKey.String(methodName)),
+		metric.WithAttributes(metricAttrs...),
 	)
 }
 

--- a/telemetry/trace.go
+++ b/telemetry/trace.go
@@ -114,10 +114,11 @@ func (t *tracer) End(ctx context.Context, span trace.Span, err error, options ..
 		return
 	}
 
-	metricAttrs := []attribute.KeyValue{
+	metricAttrs := make([]attribute.KeyValue, 0, 2+len(tenantAttrs))
+	metricAttrs = append(metricAttrs,
 		AttrStatusKey.String(ErrorCode(err)),
 		AttrMethodKey.String(methodName),
-	}
+	)
 	metricAttrs = append(metricAttrs, tenantAttrs...)
 
 	t.latencyMeasure.Record(ctx,

--- a/telemetry/trace_test.go
+++ b/telemetry/trace_test.go
@@ -1,0 +1,117 @@
+package telemetry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/pitabwire/frame/security"
+	"github.com/pitabwire/frame/telemetry"
+)
+
+func setupTracerWithRecorder(t *testing.T) (telemetry.Tracer, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	// Register the test provider globally so NewTracer picks it up.
+	otelTP := tp
+	originalTP := setGlobalTracerProvider(otelTP)
+	t.Cleanup(func() { setGlobalTracerProvider(originalTP) })
+
+	tr := telemetry.NewTracer("test/pkg")
+	return tr, recorder
+}
+
+func TestEnd_WithTenantClaims(t *testing.T) {
+	tr, recorder := setupTracerWithRecorder(t)
+
+	claims := &security.AuthenticationClaims{
+		TenantID:    "tenant-abc",
+		PartitionID: "partition-xyz",
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	ctx, span := tr.Start(ctx, "TestOp")
+	tr.End(ctx, span, nil)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+
+	attrMap := spanAttrMap(spans[0].Attributes())
+	require.Equal(t, "tenant-abc", attrMap[telemetry.AttrTenantKey])
+	require.Equal(t, "partition-xyz", attrMap[telemetry.AttrPartitionKey])
+}
+
+func TestEnd_WithoutClaims(t *testing.T) {
+	tr, recorder := setupTracerWithRecorder(t)
+
+	ctx := context.Background()
+	ctx, span := tr.Start(ctx, "TestOp")
+	tr.End(ctx, span, nil)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+
+	attrMap := spanAttrMap(spans[0].Attributes())
+	_, hasTenant := attrMap[telemetry.AttrTenantKey]
+	_, hasPartition := attrMap[telemetry.AttrPartitionKey]
+	require.False(t, hasTenant)
+	require.False(t, hasPartition)
+}
+
+func TestEnd_WithError(t *testing.T) {
+	tr, recorder := setupTracerWithRecorder(t)
+
+	claims := &security.AuthenticationClaims{
+		TenantID:    "tenant-err",
+		PartitionID: "partition-err",
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	ctx, span := tr.Start(ctx, "FailingOp")
+	tr.End(ctx, span, errors.New("something failed"))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+
+	attrMap := spanAttrMap(spans[0].Attributes())
+	require.Equal(t, "tenant-err", attrMap[telemetry.AttrTenantKey])
+	require.Equal(t, "partition-err", attrMap[telemetry.AttrPartitionKey])
+	require.Equal(t, "something failed", attrMap[telemetry.AttrErrorKey])
+}
+
+func TestEnd_PartialClaims(t *testing.T) {
+	tr, recorder := setupTracerWithRecorder(t)
+
+	claims := &security.AuthenticationClaims{
+		TenantID: "tenant-only",
+	}
+	ctx := claims.ClaimsToContext(context.Background())
+
+	ctx, span := tr.Start(ctx, "PartialOp")
+	tr.End(ctx, span, nil)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+
+	attrMap := spanAttrMap(spans[0].Attributes())
+	require.Equal(t, "tenant-only", attrMap[telemetry.AttrTenantKey])
+	_, hasPartition := attrMap[telemetry.AttrPartitionKey]
+	require.False(t, hasPartition)
+}
+
+func spanAttrMap(attrs []attribute.KeyValue) map[attribute.Key]string {
+	m := make(map[attribute.Key]string, len(attrs))
+	for _, a := range attrs {
+		m[a.Key] = a.Value.AsString()
+	}
+	return m
+}

--- a/telemetry/trace_test_helpers_test.go
+++ b/telemetry/trace_test_helpers_test.go
@@ -1,0 +1,14 @@
+package telemetry_test
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// setGlobalTracerProvider swaps the global OTel TracerProvider and returns the
+// previous one so tests can restore it during cleanup.
+func setGlobalTracerProvider(tp trace.TracerProvider) trace.TracerProvider {
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	return prev
+}


### PR DESCRIPTION
## Summary
- Add `TenantAttributes(ctx)` and `WithTenantAttributes(ctx)` helpers in `telemetry/attributes.go` to extract `tenant_id`/`partition_id` from security claims
- Enhance `Tracer.End()` to automatically include tenant attributes on spans and latency metrics
- Update `Views()` attribute filters to allow tenant/partition keys through histograms and completed_calls
- Safe when claims are absent — unauthenticated paths produce no extra attributes

## Test plan
- [x] 8 unit tests for `TenantAttributes` / `WithTenantAttributes` (nil claims, empty, partial, full, ext map)
- [x] 4 unit tests for `Tracer.End()` with span recorder (with/without claims, error, partial)
- [x] All pass with `-race`
- [x] Zero lint issues after `make format`