### PR TITLE
fix(data): DEFAULT CURRENT_TIMESTAMP on CreatedAt/ModifiedAt

### DIFF
--- a/data/model.go
+++ b/data/model.go
@@ -21,11 +21,12 @@ type BaseModelI interface {
 type BaseModel struct {
 	ID string `gorm:"type:varchar(50);primary_key"`
 	// CreatedAt and ModifiedAt are NOT NULL because BeforeCreate always
-	// populates them. Tagging them here keeps AutoMigrate from trying to
-	// relax the columns on tables that promote CreatedAt into a composite
-	// primary key (e.g. TimescaleDB hypertables).
-	CreatedAt   time.Time      `gorm:"not null"`
-	ModifiedAt  time.Time      `gorm:"not null"`
+	// populates them through GORM. The default CURRENT_TIMESTAMP keeps
+	// raw SQL seed INSERTs that omit these columns working, and keeps
+	// AutoMigrate from trying to relax the columns on tables that promote
+	// CreatedAt into a composite primary key (e.g. TimescaleDB hypertables).
+	CreatedAt   time.Time      `gorm:"not null;default:CURRENT_TIMESTAMP"`
+	ModifiedAt  time.Time      `gorm:"not null;default:CURRENT_TIMESTAMP"`
 	CreatedBy   string         `gorm:"type:varchar(50)"`
 	ModifiedBy  string         `gorm:"type:varchar(50)"`
 	Version     uint           `gorm:"DEFAULT 0"`


### PR DESCRIPTION
Follow-up to v1.94.5. Tagging NOT NULL alone broke raw SQL seed migrations that INSERT without specifying created_at/modified_at (tenant/partition/client seeds). Adding a column DEFAULT keeps those seeds working while preserving the NOT NULL invariant.