### PR TITLE
chore(lint): clean up goconst + govet inline warnings

### DIFF
--- a/client/rest_invoker.go
+++ b/client/rest_invoker.go
@@ -15,6 +15,12 @@ import (
 	"github.com/pitabwire/util"
 )
 
+// HTTP header names and well-known content types used by this client.
+const (
+	headerContentType = "Content-Type"
+	mimeJSON          = "application/json"
+)
+
 // resilientTransport is an http.RoundTripper that adds retry logic around an
 // inner transport. Requests get automatic retries on transient failures
 // (502, 503, 504, and transport errors).
@@ -216,8 +222,8 @@ func (s *invoker) Invoke(ctx context.Context,
 	headers http.Header, opts ...HTTPOption) (*InvokeResponse, error) {
 	if headers == nil {
 		headers = http.Header{
-			"Content-Type": {"application/json"},
-			"Accept":       {"application/json"},
+			headerContentType: {mimeJSON},
+			"Accept":          {mimeJSON},
 		}
 	}
 
@@ -247,7 +253,7 @@ func (s *invoker) InvokeWithURLEncoded(ctx context.Context,
 	headers http.Header, opts ...HTTPOption) (*InvokeResponse, error) {
 	if headers == nil {
 		headers = http.Header{
-			"Content-Type": []string{"application/x-www-form-urlencoded"},
+			headerContentType: []string{"application/x-www-form-urlencoded"},
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -430,11 +430,17 @@ func (c *ConfigurationDefault) ProfilerEnabled() bool {
 	return c.ProfilerEnable
 }
 
+// defaultProfilerPort is the fallback profiler bind address when none is set.
+const defaultProfilerPort = ":6060"
+
+// defaultHTTPPort is the fallback HTTP server bind address when none is set.
+const defaultHTTPPort = ":8080"
+
 func (c *ConfigurationDefault) ProfilerPort() string {
 	if c.ProfilerPortAddr != "" {
 		return c.ProfilerPortAddr
 	}
-	return ":6060"
+	return defaultProfilerPort
 }
 
 type ConfigurationPorts interface {
@@ -465,7 +471,7 @@ func (c *ConfigurationDefault) HTTPPort() string {
 		return c.HTTPServerPort
 	}
 
-	return ":8080"
+	return defaultHTTPPort
 }
 
 type ConfigurationTelemetry interface {

--- a/data/jsonmap_type.go
+++ b/data/jsonmap_type.go
@@ -99,12 +99,15 @@ func (m *JSONMap) GormDataType() string {
 	return "jsonmap"
 }
 
+// dialectMySQL is the gorm dialector name for MySQL/MariaDB.
+const dialectMySQL = "mysql"
+
 // GormDBDataType returns the dialect-specific database column type.
 func (m *JSONMap) GormDBDataType(db *gorm.DB, _ *schema.Field) string {
 	switch db.Dialector.Name() {
 	case "postgres":
 		return "JSONB"
-	case "mysql", "sqlite":
+	case dialectMySQL, "sqlite":
 		return "JSON"
 	case "sqlserver":
 		return "NVARCHAR(MAX)"
@@ -125,7 +128,7 @@ func (m *JSONMap) GormValue(_ context.Context, db *gorm.DB) clause.Expr {
 	}
 
 	switch db.Dialector.Name() {
-	case "mysql":
+	case dialectMySQL:
 		return gorm.Expr("CAST(? AS JSON)", data)
 	default:
 		return gorm.Expr("?", data)

--- a/frametests/deps/testoryhydra/hydra.go
+++ b/frametests/deps/testoryhydra/hydra.go
@@ -17,6 +17,10 @@ const (
 	// OryHydraImage is the Ory Hydra Image.
 	OryHydraImage = "oryd/hydra:latest"
 
+	// hydraContainerConfigPath is the in-container path to the hydra.yml
+	// config bind-mounted into the test container.
+	hydraContainerConfigPath = "/etc/config/hydra.yml"
+
 	HydraConfiguration = `
 ## ORY Hydra Configuration
 #
@@ -127,7 +131,7 @@ func (d *dependancy) migrateContainer(
 ) error {
 	containerRequest := testcontainers.ContainerRequest{
 		Image: d.Name(),
-		Cmd:   []string{"migrate", "sql", "up", "--read-from-env", "--yes", "--config", "/etc/config/hydra.yml"},
+		Cmd:   []string{"migrate", "sql", "up", "--read-from-env", "--yes", "--config", hydraContainerConfigPath},
 		Env: map[string]string{
 			"LOG_LEVEL": "debug",
 			"DSN":       databaseURL,
@@ -135,7 +139,7 @@ func (d *dependancy) migrateContainer(
 		Files: []testcontainers.ContainerFile{
 			{
 				Reader:            strings.NewReader(d.configuration),
-				ContainerFilePath: "/etc/config/hydra.yml",
+				ContainerFilePath: hydraContainerConfigPath,
 				FileMode:          definition.ContainerFileMode,
 			},
 		},
@@ -177,7 +181,7 @@ func (d *dependancy) Setup(ctx context.Context, ntwk *testcontainers.DockerNetwo
 
 	containerRequest := testcontainers.ContainerRequest{
 		Image: d.Name(),
-		Cmd:   []string{"serve", "all", "--config", "/etc/config/hydra.yml", "--dev"},
+		Cmd:   []string{"serve", "all", "--config", hydraContainerConfigPath, "--dev"},
 		Env: d.Opts().Env(map[string]string{
 			"LOG_LEVEL":                 "debug",
 			"LOG_LEAK_SENSITIVE_VALUES": "true",
@@ -186,7 +190,7 @@ func (d *dependancy) Setup(ctx context.Context, ntwk *testcontainers.DockerNetwo
 		Files: []testcontainers.ContainerFile{
 			{
 				Reader:            strings.NewReader(d.configuration),
-				ContainerFilePath: "/etc/config/hydra.yml",
+				ContainerFilePath: hydraContainerConfigPath,
 				FileMode:          definition.ContainerFileMode,
 			},
 		},

--- a/internal/serializer.go
+++ b/internal/serializer.go
@@ -45,7 +45,7 @@ func Unmarshal(data []byte, holder any) error {
 
 	// Fast path: reflect to get real value and type
 	rv := reflect.ValueOf(holder)
-	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return errNonPointerOrNil
 	}
 	rv = rv.Elem()
@@ -65,7 +65,7 @@ func Unmarshal(data []byte, holder any) error {
 		return nil
 
 	default:
-		if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+		if rv.Kind() == reflect.Pointer && !rv.IsNil() {
 			if pm, ok := rv.Interface().(proto.Message); ok {
 				// Reset + UnmarshalMerge is faster than Clone + Unmarshal
 				proto.Reset(pm)

--- a/security/authorizer/audit.go
+++ b/security/authorizer/audit.go
@@ -9,6 +9,10 @@ import (
 	"github.com/pitabwire/frame/security"
 )
 
+// fieldSubjectID is the structured-log key used for the subject identifier
+// across audit, ResourceAccessChecker, and TenancyPermissionChecker.
+const fieldSubjectID = "subject_id"
+
 // auditLogger implements the AuditLogger interface.
 type auditLogger struct {
 	sampleRate float64
@@ -59,7 +63,7 @@ func (a *auditLogger) LogDecision(
 		"object_id":        req.Object.ID,
 		"permission":       req.Permission,
 		"subject_ns":       req.Subject.Namespace,
-		"subject_id":       req.Subject.ID,
+		fieldSubjectID:     req.Subject.ID,
 		"allowed":          result.Allowed,
 		"checked_at":       result.CheckedAt,
 	}

--- a/security/authorizer/resource_access_checker.go
+++ b/security/authorizer/resource_access_checker.go
@@ -112,7 +112,7 @@ func (c *ResourceAccessChecker) CheckSubject(ctx context.Context, resourceID, pe
 			"object_namespace": req.Object.Namespace,
 			"object_id":        req.Object.ID,
 			"permission":       permission,
-			"subject_id":       subjectID,
+			fieldSubjectID:     subjectID,
 			"denial_source":    "constraint",
 		}).Info("authorization decision: denied by constraint")
 		return cErr

--- a/security/authorizer/tenancy_permission_checker.go
+++ b/security/authorizer/tenancy_permission_checker.go
@@ -65,8 +65,8 @@ func NewTenancyAccessChecker(
 		subjectNamespace: security.NamespaceProfile,
 		onTenancyAccessDenied: func(ctx context.Context, _ security.Authorizer, tenancyPath, subjectID string) error {
 			util.Log(ctx).WithFields(map[string]any{
-				"tenant_id":  tenancyPath,
-				"subject_id": subjectID,
+				"tenant_id":    tenancyPath,
+				fieldSubjectID: subjectID,
 			}).Error("PERMISSION DENIED: tenancy access denied")
 			return nil
 		},

--- a/tools/blueprint/generate.go
+++ b/tools/blueprint/generate.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+// monolithRuntimeMode is the FRAME_RUNTIME_MODE / blueprint label used for
+// services rendered as a single binary instead of one binary per service.
+const monolithRuntimeMode = "monolith"
+
 type GenerateOptions struct {
 	OutDir string
 }
@@ -31,7 +35,7 @@ func (bp *Blueprint) Generate(opts GenerateOptions) error {
 	modulePath, _ := moduleFromGoMod(outDir)
 
 	mode := bp.runtimeMode()
-	if len(services) == 1 && mode != "monolith" {
+	if len(services) == 1 && mode != monolithRuntimeMode {
 		return generatePolylith(outDir, modulePath, services[0])
 	}
 
@@ -306,7 +310,7 @@ func renderMainMonolith(monolith ServiceSpec, services []ServiceSpec, servicePkg
 
 func resolveMonolithSpec(bp *Blueprint, services []ServiceSpec) ServiceSpec {
 	spec := ServiceSpec{
-		Name: "monolith",
+		Name: monolithRuntimeMode,
 		Port: ":8080",
 	}
 	if bp != nil && bp.Service != nil {
@@ -362,7 +366,7 @@ func resolveMonolithQueueOptions(services []ServiceSpec) []string {
 
 func defaultMonolithName(name string) string {
 	if strings.TrimSpace(name) == "" {
-		return "monolith"
+		return monolithRuntimeMode
 	}
 	return name
 }


### PR DESCRIPTION
## Summary

A newer \`golangci-lint\` surface (the workflow uses \`version: latest\`) activates \`goconst\` and the inline-constant \`govet\` check. None of the findings are behavioural; this brings the repo back to a clean \`golangci-lint\` run on \`latest\`.

## Changes

- \`client/rest_invoker.go\`: name \`headerContentType\` (\"Content-Type\") and \`mimeJSON\` (\"application/json\") instead of repeating string literals.
- \`config/config.go\`: name \`defaultProfilerPort\` (\":6060\") and \`defaultHTTPPort\` (\":8080\").
- \`data/jsonmap_type.go\`: name \`dialectMySQL\` (\"mysql\") for gorm dialector switches.
- \`frametests/deps/testoryhydra/hydra.go\`: name \`hydraContainerConfigPath\` for the bind-mount target.
- \`security/authorizer/{audit,resource_access_checker,tenancy_permission_checker}.go\`: name \`fieldSubjectID\` for the shared structured-log key.
- \`tools/blueprint/generate.go\`: name \`monolithRuntimeMode\` for the blueprint-rendering branch.
- \`internal/serializer.go\`: switch \`reflect.Ptr\` (deprecated alias) to \`reflect.Pointer\`.

## Test plan

- [x] \`golangci-lint run ./...\` is clean on \`latest\`.
- [x] \`go test -count=1 -short ./...\` passes.

After this merges I'll rebase \#654 (the dependency bump that was blocked on these lint findings) so it can land too.