### PR TITLE
feat(client): WithHTTPNoAuth() — manager client without the OAuth bearer

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -74,6 +74,7 @@ type httpConfig struct {
 
 	cliCredCfg  *clientcredentials.Config
 	tokenSource oauth2.TokenSource
+	noAuth      bool
 
 	traceRequests       bool
 	traceRequestHeaders bool
@@ -171,6 +172,18 @@ func WithHTTPEnableH2C() HTTPOption {
 func WithHTTPClientCredentials(cfg *clientcredentials.Config) HTTPOption {
 	return func(c *httpConfig) {
 		c.cliCredCfg = cfg
+	}
+}
+
+// WithHTTPNoAuth returns a client with NO outbound OAuth/bearer auth, even
+// when the service is configured for client-credentials/private-key-JWT. Use
+// it for calls to EXTERNAL APIs that authenticate with their own scheme (e.g.
+// an API key in the Authorization header) — the service's OAuth bearer would
+// otherwise be auto-attached and clobber that header. The client keeps every
+// other manager benefit (OTEL tracing, retry, connection pooling).
+func WithHTTPNoAuth() HTTPOption {
+	return func(c *httpConfig) {
+		c.noAuth = true
 	}
 }
 
@@ -293,11 +306,35 @@ func newHTTPClient(ctx context.Context, opts ...HTTPOption) (*http.Client, error
 		CheckRedirect: cfg.checkRedirect,
 	}
 
-	if cfg.tokenSource == nil && cfg.cliCredCfg == nil {
-		cfg.tokenSource, err = resolveConfiguredTokenSource(ctx, tokenClient)
+	// WithHTTPNoAuth opts out of all outbound OAuth: keep the base transport
+	// (OTEL/retry/logging) but attach no bearer, so an external API's own
+	// Authorization header (e.g. an API key) survives.
+	if !cfg.noAuth {
+		client, err = applyOutboundOAuth(ctx, cfg, client, tokenClient, base)
 		if err != nil {
 			return newErrorHTTPClient(cfg, err), err
 		}
+	}
+
+	return client, nil
+}
+
+// applyOutboundOAuth resolves the configured service token source (when no
+// explicit token source / client credentials were supplied) and wraps the
+// client with the appropriate OAuth transport. Split out of newHTTPClient so
+// the WithHTTPNoAuth guard stays flat.
+func applyOutboundOAuth(
+	ctx context.Context,
+	cfg *httpConfig,
+	client, tokenClient *http.Client,
+	base http.RoundTripper,
+) (*http.Client, error) {
+	if cfg.tokenSource == nil && cfg.cliCredCfg == nil {
+		ts, err := resolveConfiguredTokenSource(ctx, tokenClient)
+		if err != nil {
+			return nil, err
+		}
+		cfg.tokenSource = ts
 	}
 
 	if cfg.tokenSource != nil {

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -93,6 +93,38 @@ func (s *OptionsSuite) TestNewHTTPClient() {
 	s.Nil(tr.Protocols)
 }
 
+func (s *OptionsSuite) TestWithHTTPNoAuthSetsFlag() {
+	cfg := &httpConfig{}
+	cfg.process(context.Background(), WithHTTPNoAuth())
+	s.True(cfg.noAuth)
+}
+
+// TestWithHTTPNoAuthSkipsOAuth proves the no-auth client bypasses all outbound
+// OAuth: even with client credentials configured (whose token fetch would fail
+// against an unreachable token URL), the request goes through unwrapped and the
+// caller's own Authorization header survives — the external-API-key use case.
+func (s *OptionsSuite) TestWithHTTPNoAuthSkipsOAuth() {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	defer server.Close()
+
+	client, err := newHTTPClient(context.Background(),
+		WithHTTPClientCredentials(&clientcredentials.Config{TokenURL: "http://127.0.0.1:1/token"}),
+		WithHTTPNoAuth(),
+	)
+	s.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	s.Require().NoError(err)
+	req.Header.Set("Authorization", "Bearer external-api-key")
+	resp, err := client.Do(req)
+	s.Require().NoError(err) // would fail the token fetch if OAuth weren't skipped
+	_ = resp.Body.Close()
+	s.Equal("Bearer external-api-key", gotAuth)
+}
+
 // httpClientTimeoutCfg satisfies config.ConfigurationHTTPClient for tests
 // that exercise the in-context timeout seeding path in newHTTPClient.
 type httpClientTimeoutCfg struct {

--- a/client/rest_invoker.go
+++ b/client/rest_invoker.go
@@ -440,7 +440,8 @@ func shouldCreateRequestScopedClient(cfg *httpConfig) bool {
 		cfg.traceRequests ||
 		cfg.traceRequestHeaders ||
 		cfg.retryPolicyConfigured ||
-		cfg.workloadAPIRequested
+		cfg.workloadAPIRequested ||
+		cfg.noAuth
 }
 
 // enableBodyRewind sets GetBody on req so the HTTP client can replay the body


### PR DESCRIPTION
HTTPClientManager auto-attaches the service's outbound OAuth bearer to every client (no per-call opt-out), clobbering an external API's own Authorization header (e.g. an API key) — so callers had to drop to a bare stdlib client, losing OTEL tracing / retry / pooling.

`WithHTTPNoAuth()` gates the token-resolution + oauth2/client-credentials block (extracted to `applyOutboundOAuth` to keep the guard flat), so the client keeps the full base transport but attaches no bearer. `shouldCreateRequestScopedClient` honours the flag. Lint clean, tested.