### PR TITLE
deps: bump pitabwire/util to v0.9.1 (LOG_LEVEL fan-out fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0
 	github.com/panjf2000/ants/v2 v2.12.1
 	github.com/pitabwire/natspubsub v0.8.4
-	github.com/pitabwire/util v0.9.0
+	github.com/pitabwire/util v0.9.1
 	github.com/redis/go-redis/v9 v9.20.0
 	github.com/rs/xid v1.6.0
 	github.com/spiffe/go-spiffe/v2 v2.7.0
@@ -144,3 +144,8 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 )
+
+// v1.94.12 was published accidentally on 2026-06-10 from a stale release
+// draft: the tag pointed at post-v1.98.0 main, not v1.94.x-era code, and
+// the Go module proxy had already cached it before the tag was deleted.
+retract v1.94.12

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZn
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
-github.com/pitabwire/util v0.9.0 h1:fnlTAuWKqAjc6GalO+a7hMeo6g3fAv5yjmaP237ChP4=
-github.com/pitabwire/util v0.9.0/go.mod h1:JrLiS3K4VXsLZE38LLvq1N0X2j0fs33QLz/zMXf3zc4=
+github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=
+github.com/pitabwire/util v0.9.1/go.mod h1:JrLiS3K4VXsLZE38LLvq1N0X2j0fs33QLz/zMXf3zc4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=


### PR DESCRIPTION
Picks up pitabwire/util v0.9.1 (pitabwire/util#19): `MultiHandler.Handle` now respects each child handler's `Enabled` level.

Impact for frame services: `WithLogger` attaches the OTel telemetry log handler when telemetry is enabled; its permissive `Enabled` previously caused DEBUG records to be written to stdout regardless of `LOG_LEVEL`. With this bump, `LOG_LEVEL=info` actually suppresses debug output (SQL query logs from the datastore pool logger, per-event ack logs from the events handler) on stdout.

Verified locally: `go build ./...`, `go test ./events/ ./config/ . -count=1` green with v0.9.1.