### PR TITLE
feat(frametests): add rlstest — RLS-exercising tenancy provider for test suites

### DIFF
--- a/frametests/rlstest/rlstest.go
+++ b/frametests/rlstest/rlstest.go
@@ -1,0 +1,168 @@
+// Copyright 2023-2026 Peter Bwire
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rlstest provides a test-only tenancy.Provider wrapper that
+// drops connections to an unprivileged role so Postgres FORCE ROW
+// LEVEL SECURITY is actually enforced.
+//
+// Background: the postgres testcontainer creates the application user
+// as a SUPERUSER. Per Postgres semantics, superusers bypass RLS even
+// when the policy is forced. Migrations need the elevated role (to
+// create policies, force RLS, etc.), but application queries must run
+// under a less-privileged role for the isolation guarantee to be
+// exercised by tests. Promoted from service-fintech apps/limits/tests/rlstest so every
+// frame service test suite can exercise RLS without hand-rolling the
+// role-drop pattern (mirrors tenancy/postgres provider_test.go).
+package rlstest
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"gorm.io/gorm"
+
+	"github.com/pitabwire/frame/datastore/dialect"
+	"github.com/pitabwire/frame/tenancy"
+	tenpg "github.com/pitabwire/frame/tenancy/postgres"
+
+	// Pull in the pgx stdlib driver so database/sql can dial postgres
+	// for role bootstrap and post-migration grants.
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// Role is the non-superuser role name used in tests.
+const Role = "rls_test_user"
+
+// Provider wraps the Postgres tenancy provider with hooks that switch
+// the connection's role to Role on acquire and reset on release. The
+// switch only fires after Enable has been called, so the migration
+// phase runs as the original (superuser) role.
+type Provider struct {
+	inner   *tenpg.Provider
+	enabled atomic.Bool
+}
+
+// New returns a fresh wrapper.
+func New() *Provider {
+	return &Provider{inner: tenpg.New()}
+}
+
+// Enable turns on the per-connection SET ROLE behaviour. Call after
+// migration (and after grants on the migrated tables) and before
+// issuing any application query you want to test against RLS.
+func (p *Provider) Enable() { p.enabled.Store(true) }
+
+// Name implements tenancy.Provider.
+func (p *Provider) Name() string { return "rlstest+" + p.inner.Name() }
+
+// Capabilities implements tenancy.Provider.
+func (p *Provider) Capabilities() tenancy.Capabilities { return p.inner.Capabilities() }
+
+// Install implements tenancy.Provider — delegates to the inner provider.
+func (p *Provider) Install(ctx context.Context, db *gorm.DB, models []tenancy.ModelInfo) error {
+	return p.inner.Install(ctx, db, models)
+}
+
+// WireAdapter implements tenancy.Provider. Registers our role-switch
+// hooks AFTER the inner provider's tenancy hooks so the order on each
+// acquire is: tenancy push (under superuser) → SET ROLE → query runs
+// under the restricted role with the right session vars. On release:
+// RESET ROLE → tenancy reset.
+func (p *Provider) WireAdapter(adapter dialect.DialectAdapter) error {
+	if adapter == nil {
+		return errors.New("rlstest: nil adapter")
+	}
+	if err := p.inner.WireAdapter(adapter); err != nil {
+		return err
+	}
+	if err := adapter.RegisterAcquireHook(p.beforeAcquire); err != nil {
+		return fmt.Errorf("rlstest: register acquire hook: %w", err)
+	}
+	if err := adapter.RegisterReleaseHook(p.afterRelease); err != nil {
+		return fmt.Errorf("rlstest: register release hook: %w", err)
+	}
+	return nil
+}
+
+// WireGorm implements tenancy.Provider — delegates to the inner provider.
+func (p *Provider) WireGorm(db *gorm.DB) error { return p.inner.WireGorm(db) }
+
+func (p *Provider) beforeAcquire(ctx context.Context, conn dialect.DialectConn) error {
+	if !p.enabled.Load() {
+		return nil
+	}
+	return conn.Exec(ctx, "SET ROLE "+Role)
+}
+
+func (p *Provider) afterRelease(ctx context.Context, conn dialect.DialectConn) error {
+	if !p.enabled.Load() {
+		return nil
+	}
+	return conn.Exec(ctx, "RESET ROLE")
+}
+
+// CreateRole opens a short-lived admin connection to dsn and creates
+// the non-superuser Role idempotently. Safe to call before any tables
+// exist — table-level grants must happen separately via GrantAll once
+// the schema is migrated.
+func CreateRole(ctx context.Context, dsn string) error {
+	adminDB, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return fmt.Errorf("rlstest: open admin db: %w", err)
+	}
+	defer adminDB.Close()
+	if _, err = adminDB.ExecContext(ctx, `
+		DO $$
+		BEGIN
+			IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '`+Role+`') THEN
+				CREATE ROLE `+Role+` NOLOGIN;
+			END IF;
+		END $$;
+	`); err != nil {
+		return fmt.Errorf("rlstest: create role: %w", err)
+	}
+	return nil
+}
+
+// GrantAll grants the test role enough privileges on the public schema
+// to read and write every table that exists at call time. Must be
+// invoked AFTER migration so all tables are present. Idempotent.
+func GrantAll(ctx context.Context, dsn string) error {
+	adminDB, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return fmt.Errorf("rlstest: open admin db: %w", err)
+	}
+	defer adminDB.Close()
+
+	stmts := []string{
+		`GRANT USAGE ON SCHEMA public TO ` + Role,
+		`GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA public TO ` + Role,
+		`GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO ` + Role,
+		// Default privileges so any table created later (e.g., by SQL
+		// migration files run after AutoMigrate) is also accessible.
+		`ALTER DEFAULT PRIVILEGES IN SCHEMA public ` +
+			`GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLES TO ` + Role,
+		`ALTER DEFAULT PRIVILEGES IN SCHEMA public ` +
+			`GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO ` + Role,
+	}
+	for _, stmt := range stmts {
+		if _, err = adminDB.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("rlstest: %s: %w", stmt, err)
+		}
+	}
+	return nil
+}

--- a/frametests/rlstest/rlstest_test.go
+++ b/frametests/rlstest/rlstest_test.go
@@ -1,0 +1,113 @@
+// Copyright 2023-2026 Peter Bwire
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rlstest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/pitabwire/frame/data"
+	"github.com/pitabwire/frame/datastore/pool"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/frame/frametests/rlstest"
+	"github.com/pitabwire/frame/security"
+	"github.com/pitabwire/frame/tenancy"
+	"github.com/pitabwire/frame/tests"
+)
+
+type RLSTestSuite struct {
+	tests.BaseTestSuite
+}
+
+func TestRLSTestSuite(t *testing.T) {
+	suite.Run(t, &RLSTestSuite{})
+}
+
+type rlsWidget struct {
+	data.BaseModel
+	Name string `gorm:"type:varchar(64)"`
+}
+
+func (rlsWidget) TableName() string { return "rls_widgets" }
+
+func tenantCtx(tenantID, partitionID string) context.Context {
+	claims := &security.AuthenticationClaims{TenantID: tenantID, PartitionID: partitionID}
+	claims.Subject = "user-" + tenantID
+	return claims.ClaimsToContext(context.Background())
+}
+
+// The wrapper must keep migrations on the superuser path, then — once
+// Enable is called — drop every acquired connection to the unprivileged
+// role so FORCE ROW LEVEL SECURITY actually filters cross-tenant reads.
+func (s *RLSTestSuite) TestEnableGatesRoleDrop() {
+	s.WithTestDependancies(s.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		ctx := t.Context()
+		// Randomised database per dependency permutation — the harness
+		// runs this body once per option set against shared containers.
+		randomDS, cleanup, err := dep.ByIsDatabase(ctx).GetRandomisedDS(ctx, util.RandomAlphaNumericString(8))
+		require.NoError(t, err)
+		t.Cleanup(func() { cleanup(ctx) })
+		dsn := randomDS.String()
+
+		require.NoError(t, rlstest.CreateRole(ctx, dsn))
+
+		prov := rlstest.New()
+		p := pool.NewPool(ctx, pool.WithTenancyProvider(prov))
+		require.NoError(t, p.AddConnection(ctx,
+			pool.WithConnection(dsn, false),
+			pool.WithPreparedStatements(false),
+		))
+		t.Cleanup(func() { p.Close(ctx) })
+
+		adminDB := p.DB(ctx, false)
+		require.NoError(t, adminDB.AutoMigrate(&rlsWidget{}))
+		enrolled, enrollErr := tenancy.EnrolledModels(adminDB, []any{&rlsWidget{}})
+		require.NoError(t, enrollErr)
+		require.NoError(t, prov.Install(ctx, adminDB, enrolled))
+		require.NoError(t, rlstest.GrantAll(ctx, dsn))
+
+		// Seed one row under tenant A (still superuser — Enable not called).
+		ctxA := tenantCtx("tenant-a", "part-a")
+		ctxB := tenantCtx("tenant-b", "part-b")
+		require.NoError(t, p.DB(ctxA, false).Create(&rlsWidget{Name: "a-thing"}).Error)
+
+		// Before Enable: superuser bypasses FORCE RLS, tenant B sees the row.
+		var leaked []rlsWidget
+		require.NoError(t, p.DB(ctxB, false).Find(&leaked).Error)
+		require.Len(t, leaked, 1, "superuser must bypass RLS before Enable — gate proves the test setup matters")
+
+		prov.Enable()
+
+		// After Enable: tenant B's connection drops to the unprivileged
+		// role; the app_tenancy_isolation policy filters tenant A's row.
+		var isolated []rlsWidget
+		require.NoError(t, p.DB(ctxB, false).Find(&isolated).Error)
+		require.Empty(t, isolated, "cross-tenant read must return empty under RLS")
+
+		// Tenant A still sees its own row through the restricted role.
+		var own []rlsWidget
+		require.NoError(t, p.DB(ctxA, false).Find(&own).Error)
+		require.Len(t, own, 1)
+
+		// Claim-less context (system path) keeps match-all semantics.
+		var all []rlsWidget
+		require.NoError(t, p.DB(context.Background(), false).Find(&all).Error)
+		require.Len(t, all, 1)
+	})
+}


### PR DESCRIPTION
Promotes the rlstest pattern from service-fintech/apps/limits into frame so every service suite can exercise Postgres RLS with one wrapper: `frame.WithTenancyProvider(rlstest.New())` → migrate → `rlstest.GrantAll` → `Enable()`. Includes a package test proving the Enable gate (superuser bypass before, isolation after, system match-all preserved). Needed for the fleet-wide tenant-isolation test audit remediation.