### PR TITLE
fix(tenancy): enroll models registered by value

### DIFF
--- a/tenancy/enrollment.go
+++ b/tenancy/enrollment.go
@@ -2,6 +2,7 @@ package tenancy
 
 import (
 	"fmt"
+	"reflect"
 
 	"gorm.io/gorm"
 )
@@ -25,6 +26,13 @@ func EnrolledModels(db *gorm.DB, models []any) ([]ModelInfo, error) {
 		if m == nil {
 			continue
 		}
+		// Tenanted/Unscoped are declared with pointer receivers, so a
+		// model registered BY VALUE silently failed both assertions and
+		// was skipped — leaving its table without RLS while everything
+		// else worked. Four services shipped that way (2026-06 audit).
+		// Promote values to pointers before checking so registration
+		// style cannot change enforcement.
+		m = asPointer(m)
 		if _, isUnscoped := m.(Unscoped); isUnscoped {
 			continue
 		}
@@ -57,4 +65,17 @@ func tableNameFor(db *gorm.DB, m any) (string, error) {
 		return "", fmt.Errorf("tenancy: parse model: %w", err)
 	}
 	return stmt.Table, nil
+}
+
+// asPointer returns m unchanged when it is already a pointer (or not a
+// struct); for struct values it returns a pointer to an addressable
+// copy so pointer-receiver interface checks see the full method set.
+func asPointer(m any) any {
+	v := reflect.ValueOf(m)
+	if v.Kind() != reflect.Struct {
+		return m
+	}
+	p := reflect.New(v.Type())
+	p.Elem().Set(v)
+	return p.Interface()
 }

--- a/tenancy/enrollment_value_test.go
+++ b/tenancy/enrollment_value_test.go
@@ -1,0 +1,34 @@
+package tenancy_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pitabwire/frame/data"
+	"github.com/pitabwire/frame/tenancy"
+)
+
+type valueWidget struct {
+	data.BaseModel
+	Name string
+}
+
+func (valueWidget) TableName() string { return "value_widgets" }
+
+// Models registered BY VALUE must still enroll: Tenanted has pointer
+// receivers, and four services shipped without RLS because their
+// migrate lists passed values (2026-06 audit).
+func TestEnrolledModelsAcceptsValueRegistration(t *testing.T) {
+	db := newMinimalDB(t)
+
+	byValue, err := tenancy.EnrolledModels(db, []any{valueWidget{}})
+	require.NoError(t, err)
+	byPointer, err := tenancy.EnrolledModels(db, []any{&valueWidget{}})
+	require.NoError(t, err)
+
+	require.Len(t, byPointer, 1, "pointer registration is the baseline")
+	require.Len(t, byValue, 1, "value registration must enroll identically")
+	require.Equal(t, byPointer, byValue)
+	require.Equal(t, "value_widgets", byValue[0].Table)
+}


### PR DESCRIPTION
Closes the footgun that left four services' tables without RLS (2026-06 audit): `EnrolledModels` silently skipped value-registered models because `Tenanted`/`Unscoped` are pointer-receiver interfaces. Values are now promoted to pointers before the check. Regression test included (fails on old code).