### PR TITLE
feat(telemetry): BusinessMetrics — transparently tenant-scoped instruments

### DIFF
--- a/telemetry/business.go
+++ b/telemetry/business.go
@@ -1,0 +1,169 @@
+// Copyright 2023-2026 Peter Bwire
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// BusinessMetrics is the standard factory for product/business metrics.
+// Every instrument it creates is tenant-scoped TRANSPARENTLY: each
+// measurement automatically carries tenant_id and partition_id derived
+// from the context's security claims (see TenantAttributes), so call
+// sites cannot forget tenant attribution. Unauthenticated/system paths
+// simply record without tenant attributes.
+//
+// Usage:
+//
+//	var bm = telemetry.NewBusinessMetrics("service-loans")
+//	var loansCreated = bm.Counter("loans_created_total", "New loan accounts created")
+//	...
+//	loansCreated.Add(ctx, 1) // tenant_id/partition_id attached from ctx
+type BusinessMetrics struct {
+	meter metric.Meter
+}
+
+// NewBusinessMetrics returns a factory bound to the named meter on the
+// global OTel meter provider (frame's telemetry manager sets it up).
+func NewBusinessMetrics(meterName string) *BusinessMetrics {
+	return &BusinessMetrics{meter: otel.Meter(meterName)}
+}
+
+// merged appends explicit attributes after the tenant attributes so an
+// explicit value wins if a caller (unusually) supplies tenant_id itself.
+func merged(ctx context.Context, attrs []attribute.KeyValue) metric.MeasurementOption {
+	tenant := TenantAttributes(ctx)
+	if len(attrs) == 0 && len(tenant) == 0 {
+		return metric.WithAttributes()
+	}
+	all := make([]attribute.KeyValue, 0, len(tenant)+len(attrs))
+	all = append(all, tenant...)
+	all = append(all, attrs...)
+	return metric.WithAttributes(all...)
+}
+
+// Counter is a tenant-scoped monotonic int64 counter.
+type Counter struct{ inner metric.Int64Counter }
+
+// Add increments the counter; tenant attributes come from ctx.
+func (c Counter) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	c.inner.Add(ctx, incr, merged(ctx, attrs))
+}
+
+// FloatCounter is a tenant-scoped monotonic float64 counter (amounts).
+type FloatCounter struct{ inner metric.Float64Counter }
+
+// Add increments the counter; tenant attributes come from ctx.
+func (c FloatCounter) Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue) {
+	c.inner.Add(ctx, incr, merged(ctx, attrs))
+}
+
+// Histogram is a tenant-scoped float64 histogram.
+type Histogram struct{ inner metric.Float64Histogram }
+
+// Record records a value; tenant attributes come from ctx.
+func (h Histogram) Record(ctx context.Context, value float64, attrs ...attribute.KeyValue) {
+	h.inner.Record(ctx, value, merged(ctx, attrs))
+}
+
+// Gauge is a tenant-scoped int64 gauge (last-value).
+type Gauge struct{ inner metric.Int64Gauge }
+
+// Record sets the gauge; tenant attributes come from ctx.
+func (g Gauge) Record(ctx context.Context, value int64, attrs ...attribute.KeyValue) {
+	g.inner.Record(ctx, value, merged(ctx, attrs))
+}
+
+// FloatGauge is a tenant-scoped float64 gauge (last-value).
+type FloatGauge struct{ inner metric.Float64Gauge }
+
+// Record sets the gauge; tenant attributes come from ctx.
+func (g FloatGauge) Record(ctx context.Context, value float64, attrs ...attribute.KeyValue) {
+	g.inner.Record(ctx, value, merged(ctx, attrs))
+}
+
+// Counter creates a tenant-scoped counter. On instrument-creation error
+// it returns a no-op-backed instrument (matching LatencyMeasure's
+// fallback behaviour) — metrics must never break the service.
+func (b *BusinessMetrics) Counter(name, description string, opts ...metric.Int64CounterOption) Counter {
+	allOpts := append([]metric.Int64CounterOption{
+		metric.WithDescription(description),
+		metric.WithUnit(unitDimensionless),
+	}, opts...)
+	m, err := b.meter.Int64Counter(name, allOpts...)
+	if err != nil {
+		m, _ = noop.NewMeterProvider().Meter("").Int64Counter(name)
+	}
+	return Counter{inner: m}
+}
+
+// FloatCounter creates a tenant-scoped float64 counter, suited to
+// monetary amounts in major units.
+func (b *BusinessMetrics) FloatCounter(name, description string, opts ...metric.Float64CounterOption) FloatCounter {
+	allOpts := append([]metric.Float64CounterOption{
+		metric.WithDescription(description),
+		metric.WithUnit(unitDimensionless),
+	}, opts...)
+	m, err := b.meter.Float64Counter(name, allOpts...)
+	if err != nil {
+		m, _ = noop.NewMeterProvider().Meter("").Float64Counter(name)
+	}
+	return FloatCounter{inner: m}
+}
+
+// Histogram creates a tenant-scoped histogram in milliseconds by default;
+// pass metric.WithUnit to override.
+func (b *BusinessMetrics) Histogram(name, description string, opts ...metric.Float64HistogramOption) Histogram {
+	allOpts := append([]metric.Float64HistogramOption{
+		metric.WithDescription(description),
+		metric.WithUnit(unitMilliseconds),
+	}, opts...)
+	m, err := b.meter.Float64Histogram(name, allOpts...)
+	if err != nil {
+		m, _ = noop.NewMeterProvider().Meter("").Float64Histogram(name)
+	}
+	return Histogram{inner: m}
+}
+
+// Gauge creates a tenant-scoped int64 gauge.
+func (b *BusinessMetrics) Gauge(name, description string, opts ...metric.Int64GaugeOption) Gauge {
+	allOpts := append([]metric.Int64GaugeOption{
+		metric.WithDescription(description),
+		metric.WithUnit(unitDimensionless),
+	}, opts...)
+	m, err := b.meter.Int64Gauge(name, allOpts...)
+	if err != nil {
+		m, _ = noop.NewMeterProvider().Meter("").Int64Gauge(name)
+	}
+	return Gauge{inner: m}
+}
+
+// FloatGauge creates a tenant-scoped float64 gauge.
+func (b *BusinessMetrics) FloatGauge(name, description string, opts ...metric.Float64GaugeOption) FloatGauge {
+	allOpts := append([]metric.Float64GaugeOption{
+		metric.WithDescription(description),
+		metric.WithUnit(unitDimensionless),
+	}, opts...)
+	m, err := b.meter.Float64Gauge(name, allOpts...)
+	if err != nil {
+		m, _ = noop.NewMeterProvider().Meter("").Float64Gauge(name)
+	}
+	return FloatGauge{inner: m}
+}

--- a/telemetry/business_test.go
+++ b/telemetry/business_test.go
@@ -1,0 +1,135 @@
+// Copyright 2023-2026 Peter Bwire
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/pitabwire/frame/security"
+	"github.com/pitabwire/frame/telemetry"
+)
+
+func tenantContext(tenantID, partitionID string) context.Context {
+	claims := &security.AuthenticationClaims{TenantID: tenantID, PartitionID: partitionID}
+	claims.Subject = "user-" + tenantID
+	return claims.ClaimsToContext(context.Background())
+}
+
+func collect(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	return rm
+}
+
+func dataPointAttrs(data metricdata.Aggregation) []attribute.Set {
+	switch d := data.(type) {
+	case metricdata.Sum[int64]:
+		out := make([]attribute.Set, 0, len(d.DataPoints))
+		for _, dp := range d.DataPoints {
+			out = append(out, dp.Attributes)
+		}
+		return out
+	case metricdata.Sum[float64]:
+		out := make([]attribute.Set, 0, len(d.DataPoints))
+		for _, dp := range d.DataPoints {
+			out = append(out, dp.Attributes)
+		}
+		return out
+	case metricdata.Histogram[float64]:
+		out := make([]attribute.Set, 0, len(d.DataPoints))
+		for _, dp := range d.DataPoints {
+			out = append(out, dp.Attributes)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func attrSets(rm metricdata.ResourceMetrics, name string) []attribute.Set {
+	var out []attribute.Set
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				out = append(out, dataPointAttrs(m.Data)...)
+			}
+		}
+	}
+	return out
+}
+
+// Business instruments must attach tenant_id/partition_id from the
+// context transparently — no call-site opt-in — while claim-less
+// (system) measurements record without tenant attributes, and explicit
+// per-call attributes are preserved alongside.
+func TestBusinessMetricsTenantScopedTransparently(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	bm := telemetry.NewBusinessMetrics("biz-test")
+	created := bm.Counter("things_created_total", "things created")
+	amount := bm.FloatCounter("things_amount_total", "amount of things")
+	dur := bm.Histogram("things_duration_ms", "thing duration")
+
+	ctxA := tenantContext("tenant-a", "part-a")
+	created.Add(ctxA, 1, attribute.String("kind", "gold"))
+	amount.Add(ctxA, 12.5)
+	dur.Record(ctxA, 42.0)
+
+	// System path: no claims, no tenant attributes.
+	created.Add(context.Background(), 1)
+
+	rm := collect(t, reader)
+
+	sets := attrSets(rm, "things_created_total")
+	require.Len(t, sets, 2, "tenant-scoped and system datapoints are distinct series")
+
+	var tenantSet, systemSet *attribute.Set
+	for i := range sets {
+		if _, ok := sets[i].Value("tenant_id"); ok {
+			tenantSet = &sets[i]
+		} else {
+			systemSet = &sets[i]
+		}
+	}
+	require.NotNil(t, tenantSet, "claims context must yield tenant_id")
+	require.NotNil(t, systemSet, "claim-less context must omit tenant attributes")
+
+	tid, _ := tenantSet.Value("tenant_id")
+	pid, _ := tenantSet.Value("partition_id")
+	kind, _ := tenantSet.Value("kind")
+	require.Equal(t, "tenant-a", tid.AsString())
+	require.Equal(t, "part-a", pid.AsString())
+	require.Equal(t, "gold", kind.AsString(), "explicit attributes preserved alongside tenant attributes")
+
+	for _, name := range []string{"things_amount_total", "things_duration_ms"} {
+		s := attrSets(rm, name)
+		require.NotEmpty(t, s, name)
+		v, ok := s[0].Value("tenant_id")
+		require.True(t, ok, name+" must carry tenant_id")
+		require.Equal(t, "tenant-a", v.AsString())
+	}
+}


### PR DESCRIPTION
Standard factory for business metrics where tenant_id/partition_id attach automatically from the security claims context on every Add/Record. Foundation for the fleet-wide analytics standardization. Test proves: tenant attrs present with claims, absent without, explicit attrs preserved.