### PR TITLE
feat!: standardize typed authentication and authorization contracts

### DIFF
--- a/client/oauth2/auth/audience.go
+++ b/client/oauth2/auth/audience.go
@@ -1,0 +1,28 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pitabwire/frame/config"
+)
+
+func resolveRequestedAudiences(cfg config.ConfigurationOAUTH2) ([]string, error) {
+	audiences, err := config.ParseResourceAudiences(cfg.GetOauth2RequestedAudiences())
+	if err != nil {
+		return nil, fmt.Errorf("oauth2 requested audiences: %w", err)
+	}
+	return config.ResourceAudienceStrings(audiences), nil
+}
+
+func resolveClientAssertionAudience(cfg config.ConfigurationOAUTH2, tokenURL string) (string, error) {
+	value := strings.TrimSpace(cfg.GetOauth2ClientAssertionAudience())
+	if value == "" {
+		value = tokenURL
+	}
+	audience, err := config.ParseClientAssertionAudience(value)
+	if err != nil {
+		return "", err
+	}
+	return string(audience), nil
+}

--- a/client/oauth2/auth/client_secret.go
+++ b/client/oauth2/auth/client_secret.go
@@ -72,6 +72,10 @@ func newClientSecretTokenSource(
 	if clientSecret == "" {
 		return nil, errors.New("client_secret auth requires client secret")
 	}
+	audiences, err := resolveRequestedAudiences(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	return &clientSecretTokenSource{
 		ctx:          ctx,
@@ -79,7 +83,7 @@ func newClientSecretTokenSource(
 		tokenURL:     tokenURL,
 		clientID:     clientID,
 		clientSecret: clientSecret,
-		audiences:    append([]string(nil), cfg.GetOauth2ServiceAudience()...),
+		audiences:    audiences,
 		authStyle:    style,
 		now:          time.Now,
 	}, nil

--- a/client/oauth2/auth/client_secret_test.go
+++ b/client/oauth2/auth/client_secret_test.go
@@ -14,12 +14,13 @@ import (
 )
 
 type stubOAuth2Config struct {
-	tokenEndpoint string
-	clientID      string
-	clientSecret  string
-	authMethod    string
-	privateJWT    *config.PrivateKeyJWTConfig
-	audience      []string
+	tokenEndpoint     string
+	clientID          string
+	clientSecret      string
+	authMethod        string
+	privateJWT        *config.PrivateKeyJWTConfig
+	audience          []string
+	assertionAudience string
 }
 
 func (c *stubOAuth2Config) LoadOauth2Config(context.Context) error   { return nil }
@@ -40,8 +41,9 @@ func (c *stubOAuth2Config) GetOauth2TokenEndpointAuthMethod() string { return c.
 func (c *stubOAuth2Config) GetOauth2PrivateKeyJWTConfig() *config.PrivateKeyJWTConfig {
 	return c.privateJWT
 }
-func (c *stubOAuth2Config) GetOauth2ServiceAudience() []string { return c.audience }
-func (c *stubOAuth2Config) GetOauth2ServiceAdminURI() string   { return "" }
+func (c *stubOAuth2Config) GetOauth2RequestedAudiences() []string    { return c.audience }
+func (c *stubOAuth2Config) GetOauth2ClientAssertionAudience() string { return c.assertionAudience }
+func (c *stubOAuth2Config) GetOauth2ServiceAdminURI() string         { return "" }
 
 func TestNewBasicTokenSource(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -110,7 +112,7 @@ func TestNewPostTokenSource(t *testing.T) {
 func TestNewBasicTokenSourceWithAudiences(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.NoError(t, r.ParseForm())
-		assert.Equal(t, []string{"api://a", "api://b"}, r.PostForm["audience"])
+		assert.Equal(t, []string{"https://api.example.org/a", "https://api.example.org/b"}, r.PostForm["audience"])
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"aud-tok","token_type":"Bearer","expires_in":60}`))
@@ -123,7 +125,7 @@ func TestNewBasicTokenSourceWithAudiences(t *testing.T) {
 		&stubOAuth2Config{
 			clientID:     "my-client",
 			clientSecret: "my-secret",
-			audience:     []string{"api://a", "api://b"},
+			audience:     []string{"https://api.example.org/a", "https://api.example.org/b"},
 		},
 		server.URL,
 	)

--- a/client/oauth2/auth/private_key_jwt.go
+++ b/client/oauth2/auth/private_key_jwt.go
@@ -58,13 +58,22 @@ func NewPrivateKeyJWTTokenSource(
 	if err != nil {
 		return nil, err
 	}
+	audiences, err := resolveRequestedAudiences(cfg)
+	if err != nil {
+		return nil, err
+	}
+	assertionAudience, err := resolveClientAssertionAudience(cfg, tokenURL)
+	if err != nil {
+		return nil, err
+	}
+	pkcfg.ClientAssertionAudience = assertionAudience
 
 	return &privateKeyJWTTokenSource{
 		ctx:          ctx,
 		httpClient:   httpClient,
 		tokenURL:     tokenURL,
 		clientID:     clientID,
-		audiences:    append([]string(nil), cfg.GetOauth2ServiceAudience()...),
+		audiences:    audiences,
 		config:       pkcfg,
 		signer:       jwtSigner,
 		now:          time.Now,
@@ -103,11 +112,6 @@ func (s *privateKeyJWTTokenSource) Token() (*oauth2.Token, error) {
 func (s *privateKeyJWTTokenSource) clientAssertion() (string, error) {
 	now := s.now().UTC()
 
-	audience := strings.TrimSpace(s.config.Audience)
-	if audience == "" {
-		audience = s.tokenURL
-	}
-
 	issuer := strings.TrimSpace(s.config.Issuer)
 	if issuer == "" {
 		issuer = s.clientID
@@ -121,7 +125,7 @@ func (s *privateKeyJWTTokenSource) clientAssertion() (string, error) {
 	claims := jwt.RegisteredClaims{
 		Issuer:    issuer,
 		Subject:   subject,
-		Audience:  jwt.ClaimStrings{audience},
+		Audience:  jwt.ClaimStrings{s.config.ClientAssertionAudience},
 		IssuedAt:  jwt.NewNumericDate(now),
 		NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
 		ExpiresAt: jwt.NewNumericDate(now.Add(s.assertionTTL)),

--- a/client/oauth2/auth/remote_signer.go
+++ b/client/oauth2/auth/remote_signer.go
@@ -71,9 +71,13 @@ func NewRemoteSignerTokenSource(
 		return nil, errors.New("remote signer requires signer_url")
 	}
 
-	audience := strings.TrimSpace(pkcfg.Audience)
-	if audience == "" {
-		audience = tokenURL
+	audience, err := resolveClientAssertionAudience(cfg, tokenURL)
+	if err != nil {
+		return nil, err
+	}
+	audiences, err := resolveRequestedAudiences(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	return &remoteSignerTokenSource{
@@ -84,7 +88,7 @@ func NewRemoteSignerTokenSource(
 		signerAPIKey: strings.TrimSpace(pkcfg.SignerAPIKey),
 		clientID:     clientID,
 		keyID:        strings.TrimSpace(pkcfg.KeyID),
-		audiences:    append([]string(nil), cfg.GetOauth2ServiceAudience()...),
+		audiences:    audiences,
 		audience:     audience,
 		now:          time.Now,
 	}, nil

--- a/client/oauth2/auth/remote_signer_test.go
+++ b/client/oauth2/auth/remote_signer_test.go
@@ -150,8 +150,11 @@ func (c *remoteSignerStubCfg) GetOauth2ServiceURI() string              { return
 func (c *remoteSignerStubCfg) GetOauth2ServiceClientID() string         { return c.clientID }
 func (c *remoteSignerStubCfg) GetOauth2ServiceClientSecret() string     { return "" }
 func (c *remoteSignerStubCfg) GetOauth2TokenEndpointAuthMethod() string { return "" }
-func (c *remoteSignerStubCfg) GetOauth2ServiceAudience() []string       { return nil }
-func (c *remoteSignerStubCfg) GetOauth2ServiceAdminURI() string         { return "" }
+func (c *remoteSignerStubCfg) GetOauth2RequestedAudiences() []string    { return nil }
+func (c *remoteSignerStubCfg) GetOauth2ClientAssertionAudience() string {
+	return "https://issuer.example.org/oauth2/token"
+}
+func (c *remoteSignerStubCfg) GetOauth2ServiceAdminURI() string { return "" }
 
 func (c *remoteSignerStubCfg) GetOauth2PrivateKeyJWTConfig() *config.PrivateKeyJWTConfig {
 	return &config.PrivateKeyJWTConfig{

--- a/client/oauth2/auth/token_endpoint_test.go
+++ b/client/oauth2/auth/token_endpoint_test.go
@@ -126,5 +126,6 @@ func (c *stubCfg) GetOauth2ServiceClientID() string                          { r
 func (c *stubCfg) GetOauth2ServiceClientSecret() string                      { return c.clientSecret }
 func (c *stubCfg) GetOauth2TokenEndpointAuthMethod() string                  { return "" }
 func (c *stubCfg) GetOauth2PrivateKeyJWTConfig() *config.PrivateKeyJWTConfig { return nil }
-func (c *stubCfg) GetOauth2ServiceAudience() []string                        { return nil }
+func (c *stubCfg) GetOauth2RequestedAudiences() []string                     { return nil }
+func (c *stubCfg) GetOauth2ClientAssertionAudience() string                  { return "" }
 func (c *stubCfg) GetOauth2ServiceAdminURI() string                          { return "" }

--- a/client/oauth2/source_test.go
+++ b/client/oauth2/source_test.go
@@ -21,12 +21,13 @@ import (
 )
 
 type stubOAuth2Config struct {
-	tokenEndpoint string
-	clientID      string
-	clientSecret  string
-	authMethod    string
-	privateJWT    *config.PrivateKeyJWTConfig
-	audience      []string
+	tokenEndpoint     string
+	clientID          string
+	clientSecret      string
+	authMethod        string
+	privateJWT        *config.PrivateKeyJWTConfig
+	audience          []string
+	assertionAudience string
 }
 
 func (c *stubOAuth2Config) LoadOauth2Config(context.Context) error   { return nil }
@@ -47,8 +48,14 @@ func (c *stubOAuth2Config) GetOauth2TokenEndpointAuthMethod() string { return c.
 func (c *stubOAuth2Config) GetOauth2PrivateKeyJWTConfig() *config.PrivateKeyJWTConfig {
 	return c.privateJWT
 }
-func (c *stubOAuth2Config) GetOauth2ServiceAudience() []string { return c.audience }
-func (c *stubOAuth2Config) GetOauth2ServiceAdminURI() string   { return "" }
+func (c *stubOAuth2Config) GetOauth2RequestedAudiences() []string { return c.audience }
+func (c *stubOAuth2Config) GetOauth2ClientAssertionAudience() string {
+	if c.assertionAudience != "" {
+		return c.assertionAudience
+	}
+	return "https://issuer.example.org/oauth2/token"
+}
+func (c *stubOAuth2Config) GetOauth2ServiceAdminURI() string { return "" }
 
 func TestNewTokenSourceClientSecretBasicExplicit(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/oauth2_private_key_jwt_test.go
+++ b/client/oauth2_private_key_jwt_test.go
@@ -50,8 +50,11 @@ func (c *oauth2AutoConfig) GetOauth2TokenEndpointAuthMethod() string { return c.
 func (c *oauth2AutoConfig) GetOauth2PrivateKeyJWTConfig() *config.PrivateKeyJWTConfig {
 	return c.privateJWT
 }
-func (c *oauth2AutoConfig) GetOauth2ServiceAudience() []string { return c.audience }
-func (c *oauth2AutoConfig) GetOauth2ServiceAdminURI() string   { return "" }
+func (c *oauth2AutoConfig) GetOauth2RequestedAudiences() []string { return c.audience }
+func (c *oauth2AutoConfig) GetOauth2ClientAssertionAudience() string {
+	return "https://issuer.example.org/oauth2/token"
+}
+func (c *oauth2AutoConfig) GetOauth2ServiceAdminURI() string { return "" }
 
 func TestNewHTTPClientPrivateKeyJWT(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -68,14 +71,13 @@ func TestNewHTTPClientPrivateKeyJWT(t *testing.T) {
 	)
 	t.Cleanup(restore)
 
-	var tokenURL string
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.NoError(t, r.ParseForm())
 		assert.Equal(t, "client_credentials", r.PostForm.Get("grant_type"))
 		assert.Equal(t, testClientAssertionTypeJWTBearer, r.PostForm.Get("client_assertion_type"))
 		assert.Equal(t, "frame-client", r.PostForm.Get("client_id"))
-		assert.Equal(t, []string{"api://payments"}, r.PostForm["audience"])
+		assert.Equal(t, []string{"https://api.example.org/payments"}, r.PostForm["audience"])
 
 		assertion := r.PostForm.Get("client_assertion")
 		assert.NotEmpty(t, assertion)
@@ -104,7 +106,7 @@ func TestNewHTTPClientPrivateKeyJWT(t *testing.T) {
 		}
 		assert.Equal(t, "frame-client", claims.Issuer)
 		assert.Equal(t, "frame-client", claims.Subject)
-		assert.Equal(t, []string{tokenURL}, []string(claims.Audience))
+		assert.Equal(t, []string{"https://issuer.example.org/oauth2/token"}, []string(claims.Audience))
 		assert.NotNil(t, claims.ExpiresAt)
 		assert.NotEmpty(t, claims.ID)
 
@@ -116,7 +118,6 @@ func TestNewHTTPClientPrivateKeyJWT(t *testing.T) {
 		}))
 	}))
 	defer tokenServer.Close()
-	tokenURL = tokenServer.URL
 
 	resourceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "Bearer access-token-1", r.Header.Get("Authorization"))
@@ -134,7 +135,7 @@ func TestNewHTTPClientPrivateKeyJWT(t *testing.T) {
 			Hint:     "internal",
 			KeyID:    "kid-1",
 		},
-		audience: []string{"api://payments"},
+		audience: []string{"https://api.example.org/payments"},
 	})
 
 	httpClient, err := newHTTPClient(ctx)
@@ -183,7 +184,7 @@ func TestNewHTTPClientPrivateKeyJWTAudiences(t *testing.T) {
 
 		assert.NoError(t, r.ParseForm())
 		assert.Equal(t, url.Values{
-			"audience":              {"api://a", "api://b"},
+			"audience":              {"https://api.example.org/a", "https://api.example.org/b"},
 			"client_assertion":      {r.PostForm.Get("client_assertion")},
 			"client_assertion_type": {testClientAssertionTypeJWTBearer},
 			"client_id":             {"frame-client"},
@@ -202,7 +203,7 @@ func TestNewHTTPClientPrivateKeyJWTAudiences(t *testing.T) {
 		privateJWT: &config.PrivateKeyJWTConfig{
 			Source: config.PrivateKeyJWTSourceWorkloadAPI,
 		},
-		audience: []string{"api://a", "api://b"},
+		audience: []string{"https://api.example.org/a", "https://api.example.org/b"},
 	})
 
 	httpClient, err := newHTTPClient(ctx)

--- a/config/audience.go
+++ b/config/audience.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+)
+
+const httpsScheme = "https"
+
+type ResourceAudience string
+
+type ClientAssertionAudience string
+
+type AudienceBaseURL string
+
+func ParseAudienceBaseURL(value string) (AudienceBaseURL, error) {
+	value = strings.TrimSuffix(strings.TrimSpace(value), "/")
+	if value == "" {
+		return "", errors.New("audience base URL is required")
+	}
+	if strings.Contains(value, "%") {
+		return "", errors.New("audience base URL must not be percent encoded")
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("parse audience base URL: %w", err)
+	}
+	if parsed.Scheme != httpsScheme || parsed.Host == "" {
+		return "", errors.New("audience base URL must be an absolute HTTPS URL")
+	}
+	if parsed.User != nil || parsed.Port() != "" || parsed.RawQuery != "" || parsed.ForceQuery ||
+		parsed.Fragment != "" {
+		return "", errors.New("audience base URL must not contain user information, a port, query, or fragment")
+	}
+	if parsed.Path != "" && path.Clean(parsed.Path) != parsed.Path {
+		return "", errors.New("audience base URL path must be canonical")
+	}
+
+	parsed.Host = strings.ToLower(parsed.Hostname())
+	parsed.RawPath = ""
+	return AudienceBaseURL(strings.TrimSuffix(parsed.String(), "/")), nil
+}
+
+func ParseResourceAudience(value string) (ResourceAudience, error) {
+	normalized, err := normalizeAudienceURL(value)
+	if err != nil {
+		return "", fmt.Errorf("resource audience: %w", err)
+	}
+	return ResourceAudience(normalized), nil
+}
+
+func ParseClientAssertionAudience(value string) (ClientAssertionAudience, error) {
+	normalized, err := normalizeAudienceURL(value)
+	if err != nil {
+		return "", fmt.Errorf("client assertion audience: %w", err)
+	}
+	return ClientAssertionAudience(normalized), nil
+}
+
+func ParseResourceAudiences(values []string) ([]ResourceAudience, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[ResourceAudience]struct{}, len(values))
+	audiences := make([]ResourceAudience, 0, len(values))
+	for index, value := range values {
+		audience, err := ParseResourceAudience(value)
+		if err != nil {
+			return nil, fmt.Errorf("audience %d: %w", index, err)
+		}
+		if _, exists := seen[audience]; exists {
+			return nil, fmt.Errorf("audience %d: duplicate audience %q", index, audience)
+		}
+		seen[audience] = struct{}{}
+		audiences = append(audiences, audience)
+	}
+
+	sort.Slice(audiences, func(i, j int) bool { return audiences[i] < audiences[j] })
+	return audiences, nil
+}
+
+func ResourceAudienceStrings(audiences []ResourceAudience) []string {
+	values := make([]string, len(audiences))
+	for index, audience := range audiences {
+		values[index] = string(audience)
+	}
+	return values
+}
+
+func normalizeAudienceURL(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("URL is required")
+	}
+	if strings.Contains(value, "%") {
+		return "", errors.New("percent-encoded URLs are not allowed")
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("parse URL: %w", err)
+	}
+	if parsed.Scheme != httpsScheme {
+		return "", errors.New("scheme must be https")
+	}
+	if parsed.Host == "" {
+		return "", errors.New("host is required")
+	}
+	if parsed.User != nil {
+		return "", errors.New("user information is not allowed")
+	}
+	if parsed.Port() != "" {
+		return "", errors.New("port is not allowed")
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery {
+		return "", errors.New("query is not allowed")
+	}
+	if parsed.Fragment != "" {
+		return "", errors.New("fragment is not allowed")
+	}
+	if parsed.Path == "" || parsed.Path == "/" {
+		return "", errors.New("non-root path is required")
+	}
+	if strings.HasSuffix(parsed.Path, "/") {
+		return "", errors.New("trailing slash is not allowed")
+	}
+	if cleaned := path.Clean(parsed.Path); cleaned != parsed.Path {
+		return "", errors.New("path must not contain dot or duplicate-slash segments")
+	}
+
+	parsed.Scheme = httpsScheme
+	parsed.Host = strings.ToLower(parsed.Hostname())
+	parsed.RawPath = ""
+	return parsed.String(), nil
+}

--- a/config/audience_test.go
+++ b/config/audience_test.go
@@ -1,0 +1,85 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pitabwire/frame/config"
+)
+
+func TestParseAudienceBaseURL(t *testing.T) {
+	t.Parallel()
+
+	baseURL, err := config.ParseAudienceBaseURL("https://API.EXAMPLE.ORG/platform/")
+	require.NoError(t, err)
+	require.Equal(t, config.AudienceBaseURL("https://api.example.org/platform"), baseURL)
+
+	for _, value := range []string{
+		"", "http://api.example.org", "https://api.example.org:443",
+		"https://user@api.example.org", "https://api.example.org/a/../b",
+		"https://api.example.org?x=1", "https://api.example.org/%70latform",
+	} {
+		_, parseErr := config.ParseAudienceBaseURL(value)
+		require.Error(t, parseErr, value)
+	}
+}
+
+func TestParseResourceAudience(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    config.ResourceAudience
+		wantErr bool
+	}{
+		{name: "canonical", value: "https://api.stawi.org/profile", want: "https://api.stawi.org/profile"},
+		{name: "normalizes host", value: " https://API.STAWI.ORG/profile ", want: "https://api.stawi.org/profile"},
+		{name: "empty", value: "", wantErr: true},
+		{name: "non url", value: "service_profile", wantErr: true},
+		{name: "http", value: "http://api.stawi.org/profile", wantErr: true},
+		{name: "root", value: "https://api.stawi.org/", wantErr: true},
+		{name: "port", value: "https://api.stawi.org:443/profile", wantErr: true},
+		{name: "query", value: "https://api.stawi.org/profile?a=b", wantErr: true},
+		{name: "fragment", value: "https://api.stawi.org/profile#x", wantErr: true},
+		{name: "userinfo", value: "https://user@api.stawi.org/profile", wantErr: true},
+		{name: "trailing slash", value: "https://api.stawi.org/profile/", wantErr: true},
+		{name: "dot segment", value: "https://api.stawi.org/a/../profile", wantErr: true},
+		{name: "duplicate slash", value: "https://api.stawi.org//profile", wantErr: true},
+		{name: "encoded", value: "https://api.stawi.org/%70rofile", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := config.ParseResourceAudience(test.value)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestParseResourceAudiencesRejectsDuplicatesAndSorts(t *testing.T) {
+	t.Parallel()
+
+	got, err := config.ParseResourceAudiences([]string{
+		"https://api.stawi.org/tenancy",
+		"https://api.stawi.org/profile",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []config.ResourceAudience{
+		"https://api.stawi.org/profile",
+		"https://api.stawi.org/tenancy",
+	}, got)
+
+	_, err = config.ParseResourceAudiences([]string{
+		"https://api.stawi.org/profile",
+		"https://API.STAWI.ORG/profile",
+	})
+	require.Error(t, err)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -68,15 +69,21 @@ func LoadWithOIDC[T any](ctx context.Context) (T, error) {
 	}
 
 	oauth2Cfg, ok := any(&cfg).(ConfigurationOAUTH2)
-	if ok {
-		if oauth2Cfg.GetOauth2ServiceURI() == "" {
-			return cfg, nil
-		}
-
-		err = oauth2Cfg.LoadOauth2Config(ctx)
-		if err != nil {
+	if !ok {
+		return cfg, nil
+	}
+	if validator, validatable := any(&cfg).(interface{ ValidateOAuth2Configuration() error }); validatable {
+		if err = validator.ValidateOAuth2Configuration(); err != nil {
 			return cfg, err
 		}
+	}
+	if oauth2Cfg.GetOauth2ServiceURI() == "" {
+		return cfg, nil
+	}
+
+	err = oauth2Cfg.LoadOauth2Config(ctx)
+	if err != nil {
+		return cfg, err
 	}
 
 	return cfg, nil
@@ -113,23 +120,22 @@ type OAuth2PrivateJWTKeyConfig struct {
 	SPIFFEID       string `json:"spiffe_id" yaml:"spiffe_id"`
 	Hint           string `json:"hint" yaml:"hint"`
 	KeyID          string `json:"key_id" yaml:"key_id"`
-	Audience       string `json:"audience" yaml:"audience"`
 	Issuer         string `json:"issuer" yaml:"issuer"`
 	Subject        string `json:"subject" yaml:"subject"`
 }
 
 type PrivateKeyJWTConfig struct {
-	PrivateKeyPEM  []byte
-	PrivateKeyPath string
-	Source         string
-	SignerURL      string
-	SignerAPIKey   string
-	SPIFFEID       string
-	Hint           string
-	KeyID          string
-	Audience       string
-	Issuer         string
-	Subject        string
+	PrivateKeyPEM           []byte
+	PrivateKeyPath          string
+	Source                  string
+	SignerURL               string
+	SignerAPIKey            string
+	SPIFFEID                string
+	Hint                    string
+	KeyID                   string
+	ClientAssertionAudience string
+	Issuer                  string
+	Subject                 string
 }
 
 func (c *OAuth2PrivateJWTKeyConfig) UnmarshalText(text []byte) error {
@@ -170,7 +176,6 @@ func (c *OAuth2PrivateJWTKeyConfig) IsZero() bool {
 		strings.TrimSpace(c.SPIFFEID) == "" &&
 		strings.TrimSpace(c.Hint) == "" &&
 		strings.TrimSpace(c.KeyID) == "" &&
-		strings.TrimSpace(c.Audience) == "" &&
 		strings.TrimSpace(c.Issuer) == "" &&
 		strings.TrimSpace(c.Subject) == ""
 }
@@ -183,7 +188,6 @@ func (c PrivateKeyJWTConfig) IsZero() bool {
 		strings.TrimSpace(c.SPIFFEID) == "" &&
 		strings.TrimSpace(c.Hint) == "" &&
 		strings.TrimSpace(c.KeyID) == "" &&
-		strings.TrimSpace(c.Audience) == "" &&
 		strings.TrimSpace(c.Issuer) == "" &&
 		strings.TrimSpace(c.Subject) == ""
 }
@@ -201,7 +205,6 @@ func (c *OAuth2PrivateJWTKeyConfig) ToPrivateKeyJWTConfig() *PrivateKeyJWTConfig
 		SPIFFEID:       strings.TrimSpace(c.SPIFFEID),
 		Hint:           strings.TrimSpace(c.Hint),
 		KeyID:          strings.TrimSpace(c.KeyID),
-		Audience:       strings.TrimSpace(c.Audience),
 		Issuer:         strings.TrimSpace(c.Issuer),
 		Subject:        strings.TrimSpace(c.Subject),
 	}
@@ -282,19 +285,22 @@ type ConfigurationDefault struct {
 	Oauth2ServiceURI              string                    `env:"OAUTH2_SERVICE_URI"           yaml:"oauth2_service_uri"`
 	Oauth2ServiceAdminURI         string                    `env:"OAUTH2_SERVICE_ADMIN_URI"     yaml:"oauth2_service_admin_uri"`
 	Oauth2WellKnownOIDCPath       string                    `env:"OAUTH2_WELL_KNOWN_OIDC_PATH"  yaml:"oauth2_well_known_oidc_path"  envDefault:".well-known/openid-configuration"`
-	Oauth2ServiceAudience         []string                  `env:"OAUTH2_SERVICE_AUDIENCE"      yaml:"oauth2_service_audience"`
+	Oauth2RequestedAudiences      []string                  `env:"OAUTH2_REQUESTED_AUDIENCES"  yaml:"oauth2_requested_audiences"`
+	Oauth2AudienceBaseURL         string                    `env:"OAUTH2_AUDIENCE_BASE_URL"    yaml:"oauth2_audience_base_url"`
+	Oauth2ClientAssertionAudience string                    `env:"OAUTH2_CLIENT_ASSERTION_AUDIENCE" yaml:"oauth2_client_assertion_audience"`
 	Oauth2ServiceClientID         string                    `env:"OAUTH2_SERVICE_CLIENT_ID"     yaml:"oauth2_service_client_id"`
 	Oauth2ServiceClientSecret     string                    `env:"OAUTH2_SERVICE_CLIENT_SECRET" yaml:"oauth2_service_client_secret"`
 	Oauth2TokenEndpointAuthMethod string                    `env:"OAUTH2_TOKEN_ENDPOINT_AUTH_METHOD" yaml:"oauth2_token_endpoint_auth_method"`
 	Oauth2PrivateJwtKey           OAuth2PrivateJWTKeyConfig `env:"OAUTH2_PRIVATE_JWT_KEY" yaml:"oauth2_private_jwt_key"`
 	Oauth2SignerAPIKey            string                    `env:"OAUTH2_SIGNER_API_KEY" yaml:"oauth2_signer_api_key"`
 
-	Oauth2WellKnownJwkData  string   `env:"OAUTH2_WELL_KNOWN_JWK_DATA" yaml:"oauth2_well_known_jwk_data"`
-	Oauth2JwtVerifyAudience []string `env:"OAUTH2_JWT_VERIFY_AUDIENCE" yaml:"oauth2_jwt_verify_audience"`
-	Oauth2JwtVerifyIssuer   string   `env:"OAUTH2_JWT_VERIFY_ISSUER"   yaml:"oauth2_jwt_verify_issuer"`
+	Oauth2WellKnownJwkData string `env:"OAUTH2_WELL_KNOWN_JWK_DATA" yaml:"oauth2_well_known_jwk_data"`
+	Oauth2ResourceAudience string `env:"OAUTH2_RESOURCE_AUDIENCE" yaml:"oauth2_resource_audience"`
+	Oauth2JwtVerifyIssuer  string `env:"OAUTH2_JWT_VERIFY_ISSUER" yaml:"oauth2_jwt_verify_issuer"`
 
 	AuthorizationServiceReadURI  string `env:"AUTHORIZATION_SERVICE_READ_URI"  yaml:"authorization_service_read_uri"`
 	AuthorizationServiceWriteURI string `env:"AUTHORIZATION_SERVICE_WRITE_URI" yaml:"authorization_service_write_uri"`
+	AuthorizationMode            string `env:"AUTHORIZATION_MODE" yaml:"authorization_mode" envDefault:"enforced"`
 
 	DatabasePrimaryURL             []string `env:"DATABASE_URL"             yaml:"database_url"`
 	DatabaseReplicaURL             []string `env:"REPLICA_DATABASE_URL"     yaml:"replica_database_url"`
@@ -616,7 +622,8 @@ type ConfigurationOAUTH2 interface {
 	GetOauth2ServiceClientSecret() string
 	GetOauth2TokenEndpointAuthMethod() string
 	GetOauth2PrivateKeyJWTConfig() *PrivateKeyJWTConfig
-	GetOauth2ServiceAudience() []string
+	GetOauth2RequestedAudiences() []string
+	GetOauth2ClientAssertionAudience() string
 	GetOauth2ServiceAdminURI() string
 }
 
@@ -638,6 +645,47 @@ func (c *ConfigurationDefault) LoadOauth2Config(ctx context.Context) error {
 			return err
 		}
 	}
+	if strings.TrimSpace(c.Oauth2JwtVerifyIssuer) == "" {
+		c.Oauth2JwtVerifyIssuer = strings.TrimSpace(c.GetOauth2Issuer())
+	}
+	return c.ValidateOAuth2Configuration()
+}
+
+func (c *ConfigurationDefault) ValidateOAuth2Configuration() error {
+	if strings.TrimSpace(c.Oauth2AudienceBaseURL) != "" {
+		baseURL, err := ParseAudienceBaseURL(c.Oauth2AudienceBaseURL)
+		if err != nil {
+			return err
+		}
+		c.Oauth2AudienceBaseURL = string(baseURL)
+	}
+
+	if strings.TrimSpace(c.Oauth2ResourceAudience) != "" {
+		audience, err := ParseResourceAudience(c.Oauth2ResourceAudience)
+		if err != nil {
+			return err
+		}
+		c.Oauth2ResourceAudience = string(audience)
+	}
+
+	requested, err := ParseResourceAudiences(c.Oauth2RequestedAudiences)
+	if err != nil {
+		return fmt.Errorf("requested audiences: %w", err)
+	}
+	c.Oauth2RequestedAudiences = ResourceAudienceStrings(requested)
+
+	if strings.TrimSpace(c.Oauth2ClientAssertionAudience) != "" {
+		audience, assertionErr := ParseClientAssertionAudience(c.Oauth2ClientAssertionAudience)
+		if assertionErr != nil {
+			return assertionErr
+		}
+		c.Oauth2ClientAssertionAudience = string(audience)
+	}
+
+	if strings.TrimSpace(c.Oauth2JwtVerifyIssuer) != "" && strings.TrimSpace(c.Oauth2ResourceAudience) == "" {
+		return errors.New("oauth2 resource audience is required when JWT issuer verification is configured")
+	}
+
 	return nil
 }
 func (c *ConfigurationDefault) GetOauth2WellKnownOIDC() string {
@@ -768,11 +816,20 @@ func (c *ConfigurationDefault) GetOauth2PrivateKeyJWTConfig() *PrivateKeyJWTConf
 	if cfg != nil && cfg.SignerAPIKey == "" {
 		cfg.SignerAPIKey = strings.TrimSpace(c.Oauth2SignerAPIKey)
 	}
+	if cfg != nil {
+		cfg.ClientAssertionAudience = strings.TrimSpace(c.Oauth2ClientAssertionAudience)
+	}
 
 	return cfg
 }
-func (c *ConfigurationDefault) GetOauth2ServiceAudience() []string {
-	return c.Oauth2ServiceAudience
+func (c *ConfigurationDefault) GetOauth2RequestedAudiences() []string {
+	return c.Oauth2RequestedAudiences
+}
+func (c *ConfigurationDefault) GetOauth2AudienceBaseURL() string {
+	return strings.TrimSuffix(strings.TrimSpace(c.Oauth2AudienceBaseURL), "/")
+}
+func (c *ConfigurationDefault) GetOauth2ClientAssertionAudience() string {
+	return c.Oauth2ClientAssertionAudience
 }
 func (c *ConfigurationDefault) GetOauth2ServiceAdminURI() string {
 	return c.Oauth2ServiceAdminURI
@@ -781,14 +838,14 @@ func (c *ConfigurationDefault) GetOauth2ServiceAdminURI() string {
 type ConfigurationJWTVerification interface {
 	GetOauth2WellKnownJwk() string
 	GetOauth2WellKnownJwkData() string
-	GetVerificationAudience() []string
+	GetResourceAudience() string
 	GetVerificationIssuer() string
 }
 
 var _ ConfigurationJWTVerification = new(ConfigurationDefault)
 
-func (c *ConfigurationDefault) GetVerificationAudience() []string {
-	return c.Oauth2JwtVerifyAudience
+func (c *ConfigurationDefault) GetResourceAudience() string {
+	return c.Oauth2ResourceAudience
 }
 func (c *ConfigurationDefault) GetVerificationIssuer() string {
 	return c.Oauth2JwtVerifyIssuer
@@ -807,6 +864,7 @@ func (c *ConfigurationDefault) GetTrustedDomain() string {
 type ConfigurationAuthorization interface {
 	GetAuthorizationServiceReadURI() string
 	GetAuthorizationServiceWriteURI() string
+	GetAuthorizationMode() string
 	AuthorizationServiceCanRead() bool
 	AuthorizationServiceCanWrite() bool
 }
@@ -820,6 +878,19 @@ func (c *ConfigurationDefault) GetAuthorizationServiceReadURI() string {
 func (c *ConfigurationDefault) GetAuthorizationServiceWriteURI() string {
 	return c.AuthorizationServiceWriteURI
 }
+
+func (c *ConfigurationDefault) GetAuthorizationMode() string {
+	if c.AuthorizationMode == AuthorizationModeDisabled {
+		return AuthorizationModeDisabled
+	}
+	return AuthorizationModeEnforced
+}
+
+const (
+	AuthorizationModeEnforced = "enforced"
+	AuthorizationModeDisabled = "disabled"
+)
+
 func (c *ConfigurationDefault) AuthorizationServiceCanRead() bool {
 	return c.AuthorizationServiceReadURI != ""
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -257,6 +257,7 @@ func (s *ConfigSuite) TestTLSAndAuthorizationGetters() {
 	s.Equal("key.pem", cfg.TLSCertKeyPath())
 	s.Equal("http://read", cfg.GetAuthorizationServiceReadURI())
 	s.Equal("http://write", cfg.GetAuthorizationServiceWriteURI())
+	s.Equal(AuthorizationModeEnforced, cfg.GetAuthorizationMode())
 	s.True(cfg.AuthorizationServiceCanRead())
 	s.True(cfg.AuthorizationServiceCanWrite())
 }
@@ -264,14 +265,15 @@ func (s *ConfigSuite) TestTLSAndAuthorizationGetters() {
 func (s *ConfigSuite) TestOIDCLoadAndGetters() {
 	oidcSrv := newTestOIDCServer(s.T(), false, false)
 	cfg := &ConfigurationDefault{
-		Oauth2ServiceURI:          oidcSrv.discoveryURLRoot(),
-		Oauth2WellKnownOIDCPath:   ".well-known/openid-configuration",
-		Oauth2ServiceClientID:     "client-id",
-		Oauth2ServiceClientSecret: "client-secret",
-		Oauth2ServiceAudience:     []string{"aud1"},
-		Oauth2ServiceAdminURI:     "http://admin.local",
-		Oauth2JwtVerifyAudience:   []string{"verifier"},
-		Oauth2JwtVerifyIssuer:     "issuer",
+		Oauth2ServiceURI:              oidcSrv.discoveryURLRoot(),
+		Oauth2WellKnownOIDCPath:       ".well-known/openid-configuration",
+		Oauth2ServiceClientID:         "client-id",
+		Oauth2ServiceClientSecret:     "client-secret",
+		Oauth2RequestedAudiences:      []string{"https://api.example.org/downstream"},
+		Oauth2ClientAssertionAudience: "https://issuer.example.org/oauth2/token",
+		Oauth2ServiceAdminURI:         "http://admin.local",
+		Oauth2ResourceAudience:        "https://api.example.org/service",
+		Oauth2JwtVerifyIssuer:         "issuer",
 	}
 
 	s.Require().NoError(cfg.LoadOauth2Config(context.Background()))
@@ -289,9 +291,10 @@ func (s *ConfigSuite) TestOIDCLoadAndGetters() {
 	s.Equal("client-secret", cfg.GetOauth2ServiceClientSecret())
 	s.Empty(cfg.GetOauth2TokenEndpointAuthMethod())
 	s.Nil(cfg.GetOauth2PrivateKeyJWTConfig())
-	s.Equal([]string{"aud1"}, cfg.GetOauth2ServiceAudience())
+	s.Equal([]string{"https://api.example.org/downstream"}, cfg.GetOauth2RequestedAudiences())
+	s.Equal("https://issuer.example.org/oauth2/token", cfg.GetOauth2ClientAssertionAudience())
 	s.Equal("http://admin.local", cfg.GetOauth2ServiceAdminURI())
-	s.Equal([]string{"verifier"}, cfg.GetVerificationAudience())
+	s.Equal("https://api.example.org/service", cfg.GetResourceAudience())
 	s.Equal("issuer", cfg.GetVerificationIssuer())
 }
 
@@ -299,10 +302,10 @@ func (s *ConfigSuite) TestPrivateKeyJWTGetters() {
 	cfg := &ConfigurationDefault{
 		Oauth2ServiceClientID:         "svc-client",
 		Oauth2TokenEndpointAuthMethod: "private_key_jwt",
+		Oauth2ClientAssertionAudience: "https://issuer.local/oauth2/token",
 		Oauth2PrivateJwtKey: OAuth2PrivateJWTKeyConfig{
 			PrivateKeyPEM: "pem-data",
 			KeyID:         "kid-1",
-			Audience:      "https://issuer.local/oauth2/token",
 			Issuer:        "issuer-id",
 			Subject:       "subject-id",
 		},
@@ -313,7 +316,7 @@ func (s *ConfigSuite) TestPrivateKeyJWTGetters() {
 	s.Equal("private_key_jwt", cfg.GetOauth2TokenEndpointAuthMethod())
 	s.Equal([]byte("pem-data"), privateKeyJWT.PrivateKeyPEM)
 	s.Equal("kid-1", privateKeyJWT.KeyID)
-	s.Equal("https://issuer.local/oauth2/token", privateKeyJWT.Audience)
+	s.Equal("https://issuer.local/oauth2/token", cfg.GetOauth2ClientAssertionAudience())
 	s.Equal("issuer-id", privateKeyJWT.Issuer)
 	s.Equal("subject-id", privateKeyJWT.Subject)
 }
@@ -409,6 +412,7 @@ func (s *ConfigSuite) TestLoadWithOIDC() {
 	oidcSrv := newTestOIDCServer(s.T(), false, false)
 	s.T().Setenv("OAUTH2_SERVICE_URI", oidcSrv.discoveryURLRoot())
 	s.T().Setenv("OAUTH2_WELL_KNOWN_OIDC_PATH", ".well-known/openid-configuration")
+	s.T().Setenv("OAUTH2_RESOURCE_AUDIENCE", "https://api.example.org/test-service")
 
 	loaded, err := LoadWithOIDC[oidcCfg](context.Background())
 	s.Require().NoError(err)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,13 +118,15 @@ Frame reads configuration through narrow interfaces. Implement only what you nee
 | `OAUTH2_SERVICE_URI` | empty | Base URL for OIDC provider.
 | `OAUTH2_SERVICE_ADMIN_URI` | empty | Admin endpoint (if supported).
 | `OAUTH2_WELL_KNOWN_OIDC_PATH` | `.well-known/openid-configuration` | OIDC discovery path.
-| `OAUTH2_SERVICE_AUDIENCE` | empty | Expected audience values.
+| `OAUTH2_REQUESTED_AUDIENCES` | empty | Canonical HTTPS resource audiences requested for outbound tokens.
+| `OAUTH2_AUDIENCE_BASE_URL` | empty | Environment-level canonical audience base used by catalog-backed clients.
+| `OAUTH2_RESOURCE_AUDIENCE` | empty | Single canonical HTTPS audience accepted by this resource server.
+| `OAUTH2_CLIENT_ASSERTION_AUDIENCE` | discovered token endpoint | Token endpoint audience for `private_key_jwt` assertions.
 | `OAUTH2_SERVICE_CLIENT_ID` | empty | Client ID.
 | `OAUTH2_SERVICE_CLIENT_SECRET` | empty | Client secret.
 | `OAUTH2_TOKEN_ENDPOINT_AUTH_METHOD` | empty | OAuth2 token endpoint client authentication method. When omitted, `private_key_jwt` is inferred if `OAUTH2_PRIVATE_JWT_KEY` is set.
-| `OAUTH2_PRIVATE_JWT_KEY` | empty | JSON object for private key JWT client auth. Supports `private_key_pem`, `private_key_path`, `source`, `spiffe_id`, `hint`, `key_id`, `audience`, `issuer`, and `subject`.
+| `OAUTH2_PRIVATE_JWT_KEY` | empty | JSON object for private key JWT client auth. Supports `private_key_pem`, `private_key_path`, `source`, `spiffe_id`, `hint`, `key_id`, `issuer`, and `subject`.
 | `OAUTH2_WELL_KNOWN_JWK_DATA` | empty | Pre-fetched JWKS JSON.
-| `OAUTH2_JWT_VERIFY_AUDIENCE` | empty | JWT audience verification.
 | `OAUTH2_JWT_VERIFY_ISSUER` | empty | JWT issuer verification.
 
 ### Authorization
@@ -133,6 +135,7 @@ Frame reads configuration through narrow interfaces. Implement only what you nee
 | --- | --- | --- |
 | `AUTHORIZATION_SERVICE_READ_URI` | empty | Read API for authorization service.
 | `AUTHORIZATION_SERVICE_WRITE_URI` | empty | Write API for authorization service.
+| `AUTHORIZATION_MODE` | `enforced` | `enforced` fails closed when authorization is unavailable; `disabled` is for explicit local tests only.
 
 ### Datastore
 

--- a/docs/security-authentication.md
+++ b/docs/security-authentication.md
@@ -14,11 +14,13 @@ Required:
 
 - `OAUTH2_SERVICE_URI`
 - `OAUTH2_WELL_KNOWN_OIDC_PATH` (default `.well-known/openid-configuration`)
-
-Optional:
-
-- `OAUTH2_JWT_VERIFY_AUDIENCE`
+- `OAUTH2_RESOURCE_AUDIENCE`
 - `OAUTH2_JWT_VERIFY_ISSUER`
+
+Outbound OAuth clients additionally use:
+
+- `OAUTH2_REQUESTED_AUDIENCES`
+- `OAUTH2_CLIENT_ASSERTION_AUDIENCE`
 
 ## Authenticate a Token
 

--- a/security/authorizer/client.go
+++ b/security/authorizer/client.go
@@ -3,6 +3,7 @@ package authorizer
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"time"
 
@@ -27,6 +28,7 @@ type ketoAdapter struct {
 	expandClient rts.ExpandServiceClient
 	config       config.ConfigurationAuthorization
 	auditLogger  security.AuditLogger
+	disabled     bool
 }
 
 // NewKetoAdapter creates a new Keto adapter with the given configuration.
@@ -41,6 +43,7 @@ func NewKetoAdapter(
 	adapter := &ketoAdapter{
 		config:      cfg,
 		auditLogger: auditLogger,
+		disabled:    cfg.GetAuthorizationMode() == config.AuthorizationModeDisabled,
 	}
 
 	if cfg.AuthorizationServiceCanRead() {
@@ -103,6 +106,9 @@ func (k *ketoAdapter) canWrite() bool {
 // Check verifies if a subject has permission on an object.
 func (k *ketoAdapter) Check(ctx context.Context, req security.CheckRequest) (security.CheckResult, error) {
 	if !k.canRead() {
+		if !k.disabled {
+			return security.CheckResult{}, errors.New("authorization is enforced but the read service is unavailable")
+		}
 		return security.CheckResult{
 			Allowed:   true,
 			Reason:    "keto disabled - permissive mode",
@@ -147,6 +153,9 @@ func (k *ketoAdapter) BatchCheck(
 	requests []security.CheckRequest,
 ) ([]security.CheckResult, error) {
 	if !k.canRead() {
+		if !k.disabled {
+			return nil, errors.New("authorization is enforced but the read service is unavailable")
+		}
 		results := make([]security.CheckResult, len(requests))
 		for i := range results {
 			results[i] = security.CheckResult{
@@ -203,7 +212,10 @@ func (k *ketoAdapter) WriteTuple(ctx context.Context, tuple security.RelationTup
 // transaction. Tuples that already exist are skipped to prevent duplicates.
 func (k *ketoAdapter) WriteTuples(ctx context.Context, tuples []security.RelationTuple) error {
 	if !k.canWrite() {
-		return nil
+		if k.disabled {
+			return nil
+		}
+		return errors.New("authorization is enforced but the write service is unavailable")
 	}
 
 	if len(tuples) == 0 {
@@ -212,7 +224,11 @@ func (k *ketoAdapter) WriteTuples(ctx context.Context, tuples []security.Relatio
 
 	var missing []security.RelationTuple
 	for _, t := range tuples {
-		if k.tupleExists(ctx, t) {
+		exists, err := k.tupleExists(ctx, t)
+		if err != nil {
+			return err
+		}
+		if exists {
 			continue
 		}
 		missing = append(missing, t)
@@ -240,25 +256,44 @@ func (k *ketoAdapter) WriteTuples(ctx context.Context, tuples []security.Relatio
 	return nil
 }
 
-// tupleExists checks whether a relation tuple already exists using the Check API.
-func (k *ketoAdapter) tupleExists(ctx context.Context, t security.RelationTuple) bool {
-	if k.checkClient == nil {
-		return false
+// tupleExists checks direct tuple storage. Authorization Check cannot be used
+// because computed relations may permit access without the requested tuple existing.
+func (k *ketoAdapter) tupleExists(ctx context.Context, t security.RelationTuple) (bool, error) {
+	if k.readClient == nil {
+		return false, errors.New("authorization read client is required for idempotent tuple writes")
 	}
 
-	resp, err := k.checkClient.Check(ctx, &rts.CheckRequest{
-		Tuple: &rts.RelationTuple{
-			Namespace: t.Object.Namespace,
-			Object:    t.Object.ID,
-			Relation:  t.Relation,
+	namespace := t.Object.Namespace
+	object := t.Object.ID
+	relation := t.Relation
+	resp, err := k.readClient.ListRelationTuples(ctx, &rts.ListRelationTuplesRequest{
+		RelationQuery: &rts.RelationQuery{
+			Namespace: &namespace,
+			Object:    &object,
+			Relation:  &relation,
 			Subject:   toKetoSubject(t.Subject),
 		},
 	})
 	if err != nil {
-		return false
+		return false, NewAuthzServiceError("read_exact_tuple", err)
 	}
 
-	return resp.GetAllowed()
+	for _, stored := range resp.GetRelationTuples() {
+		if relationTuplesEqual(fromKetoTuple(stored), t) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func relationTuplesEqual(left, right security.RelationTuple) bool {
+	return left.Object == right.Object &&
+		left.Relation == right.Relation &&
+		left.Subject.ID == right.Subject.ID &&
+		left.Subject.Relation == right.Subject.Relation &&
+		(left.Subject.Namespace == right.Subject.Namespace ||
+			(left.Subject.Namespace == security.NamespaceProfile && right.Subject.Namespace == "") ||
+			(right.Subject.Namespace == security.NamespaceProfile && left.Subject.Namespace == ""))
 }
 
 // DeleteTuple removes a relationship tuple.
@@ -269,7 +304,10 @@ func (k *ketoAdapter) DeleteTuple(ctx context.Context, tuple security.RelationTu
 // DeleteTuples removes multiple relationship tuples in a single transaction.
 func (k *ketoAdapter) DeleteTuples(ctx context.Context, tuples []security.RelationTuple) error {
 	if !k.canWrite() {
-		return nil
+		if k.disabled {
+			return nil
+		}
+		return errors.New("authorization is enforced but the write service is unavailable")
 	}
 
 	if len(tuples) == 0 {
@@ -297,7 +335,10 @@ func (k *ketoAdapter) DeleteTuples(ctx context.Context, tuples []security.Relati
 // ListRelations returns all relations for an object.
 func (k *ketoAdapter) ListRelations(ctx context.Context, object security.ObjectRef) ([]security.RelationTuple, error) {
 	if !k.canRead() {
-		return []security.RelationTuple{}, nil
+		if k.disabled {
+			return []security.RelationTuple{}, nil
+		}
+		return nil, errors.New("authorization is enforced but the read service is unavailable")
 	}
 
 	resp, err := k.readClient.ListRelationTuples(ctx, &rts.ListRelationTuplesRequest{
@@ -325,7 +366,10 @@ func (k *ketoAdapter) ListSubjectRelations(
 	namespace string,
 ) ([]security.RelationTuple, error) {
 	if !k.canRead() {
-		return []security.RelationTuple{}, nil
+		if k.disabled {
+			return []security.RelationTuple{}, nil
+		}
+		return nil, errors.New("authorization is enforced but the read service is unavailable")
 	}
 
 	query := &rts.RelationQuery{
@@ -357,7 +401,10 @@ func (k *ketoAdapter) Expand(
 	relation string,
 ) ([]security.SubjectRef, error) {
 	if !k.canRead() {
-		return []security.SubjectRef{}, nil
+		if k.disabled {
+			return []security.SubjectRef{}, nil
+		}
+		return nil, errors.New("authorization is enforced but the read service is unavailable")
 	}
 
 	resp, err := k.expandClient.Expand(ctx, &rts.ExpandRequest{

--- a/security/authorizer/client_test.go
+++ b/security/authorizer/client_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pitabwire/frame/config"
 	"github.com/pitabwire/frame/frametests/definition"
@@ -105,8 +107,20 @@ func (s *AuthorizerTestSuite) newAdapter(auditLogger security.AuditLogger) secur
 }
 
 func (s *AuthorizerTestSuite) permissiveAdapter() security.Authorizer {
-	cfg := &config.ConfigurationDefault{}
+	cfg := &config.ConfigurationDefault{AuthorizationMode: config.AuthorizationModeDisabled}
 	return authorizer.NewKetoAdapter(cfg, nil)
+}
+
+func (s *AuthorizerTestSuite) TestEnforcedModeFailsClosedWithoutKeto() {
+	adapter := authorizer.NewKetoAdapter(&config.ConfigurationDefault{}, nil)
+	result, err := adapter.Check(s.T().Context(), security.CheckRequest{
+		Object:     security.ObjectRef{Namespace: "resource", ID: "obj-1"},
+		Permission: "view",
+		Subject:    security.SubjectRef{ID: "user-1"},
+	})
+	s.Require().Error(err)
+	s.False(result.Allowed)
+	s.Require().Error(adapter.WriteTuple(s.T().Context(), security.RelationTuple{}))
 }
 
 // ---------------------------------------------------------------------------
@@ -746,6 +760,23 @@ func (s *AuthorizerTestSuite) TestAuthzServiceErrorUnwrap() {
 	innerErr := errors.New("timeout")
 	err := authorizer.NewAuthzServiceError("expand", innerErr)
 	s.ErrorIs(err, innerErr)
+}
+
+func (s *AuthorizerTestSuite) TestAuthzServiceErrorClassification() {
+	schemaErr := authorizer.NewAuthzServiceError(
+		"write_tuples",
+		status.Error(codes.NotFound, "namespace is not loaded"),
+	)
+	s.Equal(codes.NotFound, schemaErr.Code)
+	s.True(schemaErr.SchemaReadiness)
+	s.False(schemaErr.Retryable)
+
+	retryErr := authorizer.NewAuthzServiceError(
+		"write_tuples",
+		status.Error(codes.Unavailable, "temporarily unavailable"),
+	)
+	s.True(retryErr.Retryable)
+	s.False(retryErr.SchemaReadiness)
 }
 
 // ---------------------------------------------------------------------------

--- a/security/authorizer/errors.go
+++ b/security/authorizer/errors.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/pitabwire/frame/security"
 )
 
@@ -59,8 +62,11 @@ func (e *PermissionDeniedError) Unwrap() error {
 
 // AuthzServiceError wraps authorization service errors with context.
 type AuthzServiceError struct {
-	Operation string
-	Cause     error
+	Operation       string
+	Code            codes.Code
+	Retryable       bool
+	SchemaReadiness bool
+	Cause           error
 }
 
 // Error implements the error interface.
@@ -95,8 +101,24 @@ func NewPermissionDeniedError(
 
 // NewAuthzServiceError creates a new AuthzServiceError.
 func NewAuthzServiceError(operation string, cause error) *AuthzServiceError {
+	code := status.Code(cause)
 	return &AuthzServiceError{
-		Operation: operation,
-		Cause:     cause,
+		Operation:       operation,
+		Code:            code,
+		Retryable:       retryableAuthorizationCode(code),
+		SchemaReadiness: operation == "write_tuples" && (code == codes.NotFound || code == codes.FailedPrecondition),
+		Cause:           cause,
 	}
+}
+
+func retryableAuthorizationCode(code codes.Code) bool {
+	switch code {
+	case codes.Aborted, codes.DeadlineExceeded, codes.Internal, codes.ResourceExhausted, codes.Unavailable:
+		return true
+	case codes.OK, codes.Canceled, codes.Unknown, codes.InvalidArgument, codes.NotFound,
+		codes.AlreadyExists, codes.PermissionDenied, codes.FailedPrecondition, codes.OutOfRange,
+		codes.Unimplemented, codes.DataLoss, codes.Unauthenticated:
+		return false
+	}
+	return false
 }

--- a/security/openid/jwt_token_authenticator.go
+++ b/security/openid/jwt_token_authenticator.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,9 +29,10 @@ const (
 )
 
 type jwtTokenAuthenticator struct {
-	jwtVerificationAudience []string
-	jwtVerificationIssuer   string
-	tokenAuthenticator      *TokenAuthenticator
+	resourceAudience      string
+	jwtVerificationIssuer string
+	tokenAuthenticator    *TokenAuthenticator
+	initializationError   error
 }
 
 func (a *jwtTokenAuthenticator) keyFunc(token *jwt.Token) (any, error) {
@@ -49,16 +51,29 @@ func NewJwtTokenAuthenticator(cfg config.ConfigurationJWTVerification) security.
 
 	// If JWK data is pre-loaded (e.g. from OAUTH2_WELL_KNOWN_JWK_DATA env var),
 	// parse it directly so keys are available even without a reachable JWKS URL.
+	var initializationError error
 	if jwkData := cfg.GetOauth2WellKnownJwkData(); jwkData != "" {
-		_ = auth.LoadFromJSON([]byte(jwkData))
+		if err := auth.LoadFromJSON([]byte(jwkData)); err != nil {
+			initializationError = fmt.Errorf("load configured JWKS: %w", err)
+		}
+	}
+
+	resourceAudience, err := config.ParseResourceAudience(cfg.GetResourceAudience())
+	if err != nil {
+		initializationError = errors.Join(initializationError, err)
+	}
+	issuer := strings.TrimSpace(cfg.GetVerificationIssuer())
+	if issuer == "" {
+		initializationError = errors.Join(initializationError, errors.New("JWT verification issuer is required"))
 	}
 
 	auth.Start()
 
 	return &jwtTokenAuthenticator{
-		jwtVerificationAudience: cfg.GetVerificationAudience(),
-		jwtVerificationIssuer:   cfg.GetVerificationIssuer(),
-		tokenAuthenticator:      auth,
+		resourceAudience:      string(resourceAudience),
+		jwtVerificationIssuer: issuer,
+		tokenAuthenticator:    auth,
+		initializationError:   initializationError,
 	}
 }
 
@@ -74,9 +89,10 @@ func (a *jwtTokenAuthenticator) Authenticate(
 	jwtToken string,
 	options ...security.AuthOption,
 ) (context.Context, error) {
+	if a.initializationError != nil {
+		return ctx, a.initializationError
+	}
 	securityOpts := security.AuthOptions{
-		Audience:        a.jwtVerificationAudience,
-		Issuer:          a.jwtVerificationIssuer,
 		DisableSecurity: false,
 	}
 
@@ -86,14 +102,10 @@ func (a *jwtTokenAuthenticator) Authenticate(
 
 	claims := &security.AuthenticationClaims{}
 
-	var parseOptions []jwt.ParserOption
-
-	if len(securityOpts.Audience) > 0 {
-		parseOptions = append(parseOptions, jwt.WithAudience(securityOpts.Audience...))
-	}
-
-	if securityOpts.Issuer != "" {
-		parseOptions = append(parseOptions, jwt.WithIssuer(securityOpts.Issuer))
+	parseOptions := []jwt.ParserOption{
+		jwt.WithAudience(a.resourceAudience),
+		jwt.WithIssuer(a.jwtVerificationIssuer),
+		jwt.WithValidMethods([]string{"RS256", "ES256", "EdDSA"}),
 	}
 
 	token, err := jwt.ParseWithClaims(jwtToken, claims, a.keyFunc, parseOptions...)

--- a/security/openid/jwt_token_authenticator_test.go
+++ b/security/openid/jwt_token_authenticator_test.go
@@ -44,7 +44,7 @@ type JwtAuthenticatorTestSuite struct {
 	ed25519Key ed25519.PrivateKey
 	ed25519Kid string
 	// Test configuration
-	testAudience []string
+	testAudience string
 	testIssuer   string
 }
 
@@ -85,7 +85,7 @@ func (s *JwtAuthenticatorTestSuite) setupTestKeys() {
 	_ = ed25519Pub // We only need the private key for signing
 	s.ed25519Kid = "ed25519-key-1"
 	// Test configuration
-	s.testAudience = []string{"test-audience", "another-audience"}
+	s.testAudience = "https://api.example.org/test-resource"
 	s.testIssuer = "https://test-issuer.example.com"
 }
 
@@ -189,7 +189,7 @@ func (s *JwtAuthenticatorTestSuite) createAuthenticator() security.Authenticator
 // mockJWTConfig is a test-specific config that returns our mock JWKS URL.
 type mockJWTConfig struct {
 	jwksURL  string
-	audience []string
+	audience string
 	issuer   string
 }
 
@@ -197,7 +197,7 @@ func (m *mockJWTConfig) GetOauth2WellKnownJwk() string {
 	return m.jwksURL
 }
 
-func (m *mockJWTConfig) GetVerificationAudience() []string {
+func (m *mockJWTConfig) GetResourceAudience() string {
 	return m.audience
 }
 
@@ -319,7 +319,7 @@ func (s *JwtAuthenticatorTestSuite) TestInvalidTokens() {
 		{
 			name:        "missing kid header",
 			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-			expectError: "token missing kid header",
+			expectError: "signing method HS256 is invalid",
 		},
 		{
 			name:        "expired token",
@@ -353,13 +353,13 @@ func (s *JwtAuthenticatorTestSuite) TestInvalidTokens() {
 func (s *JwtAuthenticatorTestSuite) TestAudienceIssuerValidation() {
 	testCases := []struct {
 		name        string
-		audience    []string
+		audience    string
 		issuer      string
 		expectError string
 	}{
 		{
 			name:        "wrong audience",
-			audience:    []string{"wrong-audience"},
+			audience:    "https://api.example.org/wrong-resource",
 			issuer:      s.testIssuer,
 			expectError: "token has invalid audience",
 		},
@@ -371,7 +371,7 @@ func (s *JwtAuthenticatorTestSuite) TestAudienceIssuerValidation() {
 		},
 		{
 			name:        "both wrong",
-			audience:    []string{"wrong-audience"},
+			audience:    "https://api.example.org/wrong-resource",
 			issuer:      "https://wrong-issuer.com",
 			expectError: "token has invalid audience",
 		},
@@ -659,14 +659,14 @@ func BenchmarkAuthentication(b *testing.B) {
 	}))
 	defer server.Close()
 	cfg := &config.ConfigurationDefault{
-		Oauth2JwtVerifyAudience: []string{"bench-audience"},
-		Oauth2JwtVerifyIssuer:   "https://bench-issuer.com",
+		Oauth2ResourceAudience: "https://api.example.org/benchmark",
+		Oauth2JwtVerifyIssuer:  "https://bench-issuer.com",
 	}
 	auth := openid.NewJwtTokenAuthenticator(cfg)
 	// Create benchmark token
 	claims := jwt.MapClaims{
 		"iss": "https://bench-issuer.com",
-		"aud": []string{"bench-audience"},
+		"aud": []string{"https://api.example.org/benchmark"},
 		"sub": "bench-user",
 		"exp": time.Now().Add(time.Hour).Unix(),
 		"iat": time.Now().Unix(),

--- a/security/options_authenticator.go
+++ b/security/options_authenticator.go
@@ -9,8 +9,6 @@ import (
 // AuthOptions contains configuration for Redis cache.
 type AuthOptions struct {
 	DisableSecurityCfg config.ConfigurationSecurity
-	Audience           []string
-	Issuer             string
 	DisableSecurity    bool
 }
 
@@ -20,20 +18,6 @@ type AuthOption func(ctx context.Context, opts *AuthOptions)
 func WithDisableSecurityConfig(cfg config.ConfigurationSecurity) AuthOption {
 	return func(_ context.Context, opts *AuthOptions) {
 		opts.DisableSecurityCfg = cfg
-	}
-}
-
-// WithAudience sets the audience to use overriding any config option.
-func WithAudience(audience ...string) AuthOption {
-	return func(_ context.Context, opts *AuthOptions) {
-		opts.Audience = audience
-	}
-}
-
-// WithIssuer sets the issuer to use overriding any config option.
-func WithIssuer(issuer string) AuthOption {
-	return func(_ context.Context, opts *AuthOptions) {
-		opts.Issuer = issuer
 	}
 }
 

--- a/security/security_claims_test.go
+++ b/security/security_claims_test.go
@@ -135,78 +135,21 @@ func (m *mockJWTConfig) GetOauth2WellKnownJwk() string {
 	return m.jwksURL
 }
 
-// TestSimpleAuthenticate tests basic JWT authentication.
+// TestSimpleAuthenticate rejects tokens issued for a non-canonical audience.
 func (s *AuthenticationTestSuite) TestSimpleAuthenticate() {
-	testCases := []struct {
-		name         string
-		accessKey    string
-		audience     string
-		issuer       string
-		expectError  bool
-		expectClaims bool
-	}{
-		{
-			name:         "valid authentication with sample key",
-			accessKey:    sampleAccessKey,
-			audience:     "",
-			issuer:       "",
-			expectError:  false,
-			expectClaims: true,
+	auth := openid.NewJwtTokenAuthenticator(&mockJWTConfig{
+		ConfigurationDefault: config.ConfigurationDefault{
+			Oauth2ResourceAudience: "https://api.example.org/authentication",
+			Oauth2JwtVerifyIssuer:  "http://127.0.0.1:4444/",
 		},
-		{
-			name:         "authentication with specific audience",
-			accessKey:    sampleAccessKey,
-			audience:     "c2f4j7au6s7f91uqnokg",
-			issuer:       "",
-			expectError:  false,
-			expectClaims: true,
-		},
-		{
-			name:         "authentication with specific issuer",
-			accessKey:    sampleAccessKey,
-			audience:     "",
-			issuer:       "http://127.0.0.1:4444/",
-			expectError:  false,
-			expectClaims: true,
-		},
-	}
+		jwksURL: s.jwksURL,
+	})
 
-	for _, tc := range testCases {
-		s.Run(tc.name, func() {
-			// Create authenticator directly with mock config
-			auth := openid.NewJwtTokenAuthenticator(&mockJWTConfig{
-				ConfigurationDefault: config.ConfigurationDefault{
-					Oauth2JwtVerifyAudience: []string{"c2f4j7au6s7f91uqnokg"},
-					Oauth2JwtVerifyIssuer:   "http://127.0.0.1:4444/",
-				},
-				jwksURL: s.jwksURL,
-			})
-
-			ctx := s.T().Context()
-
-			var opts []security.AuthOption
-			if tc.audience != "" {
-				opts = append(opts, security.WithAudience(tc.audience))
-			}
-			if tc.issuer != "" {
-				opts = append(opts, security.WithIssuer(tc.issuer))
-			}
-
-			ctx2, err := auth.Authenticate(ctx, tc.accessKey, opts...)
-
-			if tc.expectError {
-				s.Require().Error(err, "expected authentication to fail")
-				return
-			}
-
-			s.Require().NoError(err, "authentication should succeed")
-
-			if tc.expectClaims {
-				claims := security.ClaimsFromContext(ctx2)
-				s.Require().NotNil(claims, "expected authentication claims in context")
-			}
-		})
-	}
+	ctx := s.T().Context()
+	ctx2, err := auth.Authenticate(ctx, sampleAccessKey)
+	s.Require().Error(err)
+	s.Equal(ctx, ctx2)
+	s.Nil(security.ClaimsFromContext(ctx2))
 }
 
 // TestSimpleAuthenticateWithOIDC tests OIDC configuration loading.
@@ -227,6 +170,7 @@ func (s *AuthenticationTestSuite) TestSimpleAuthenticateWithOIDC() {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Setenv("OAUTH2_SERVICE_URI", tc.serviceURI)
+				t.Setenv("OAUTH2_RESOURCE_AUDIENCE", "https://api.example.org/test-service")
 
 				ctx := t.Context()
 				cfg, err := config.LoadWithOIDC[config.ConfigurationDefault](ctx)


### PR DESCRIPTION
## Summary\n\n- introduce canonical typed URL audiences for resource tokens, requested recipients, and OAuth client assertions\n- validate audience configuration as absolute HTTPS URLs and derive resource audiences from the configurable base URL\n- enforce exact issuer, audience, and signing-algorithm checks during JWT verification\n- make authorization enforcement explicit and fail closed by default\n- classify authorization failures with typed errors and make exact Keto tuple writes idempotent\n- remove per-request audience overrides and the ambiguous legacy verifier/service audience settings\n- document the hard-switch configuration contract\n\n## Breaking configuration\n\nServices must configure the new contract:\n\n- OAUTH2_RESOURCE_AUDIENCE: this service's canonical resource URL\n- OAUTH2_REQUESTED_AUDIENCES: canonical resource URL recipients requested from the token issuer\n- OAUTH2_CLIENT_ASSERTION_AUDIENCE: exact OAuth token endpoint URL\n- OAUTH2_AUDIENCE_BASE_URL: configurable canonical API base used to derive resource URLs\n- AUTHORIZATION_MODE=enforced|disabled: explicit authorization mode; unset or invalid values fail closed\n\nThe previous service/verifier audience fields and request-level audience override are intentionally removed. This is a hard switch with no compatibility layer.\n\n## Verification\n\n- make format (0 lint issues)\n- GOWORK=off go test ./...\n- git diff --check\n\nRefs #673